### PR TITLE
fix: handle react-starter fund-wallet async errors

### DIFF
--- a/privy-react-starter/src/components/sections/fund-wallet.tsx
+++ b/privy-react-starter/src/components/sections/fund-wallet.tsx
@@ -48,7 +48,7 @@ const FundWallet = () => {
 
   const isEvmWallet = selectedWallet?.type === "ethereum";
   const isSolanaWallet = selectedWallet?.type === "solana";
-  const fundWalletEvmHandler = (
+  const fundWalletEvmHandler = async (
     asset?:
       | {
           erc20: Hex;
@@ -61,7 +61,7 @@ const FundWallet = () => {
       return;
     }
     try {
-      fundWalletEvm(selectedWallet.address, {
+      await fundWalletEvm(selectedWallet.address, {
         amount: "1",
         ...(asset && { asset }),
       });
@@ -70,13 +70,13 @@ const FundWallet = () => {
       showErrorToast("Failed to fund wallet. Please try again.");
     }
   };
-  const fundWalletSolanaHandler = (asset?: "USDC" | "native-currency") => {
+  const fundWalletSolanaHandler = async (asset?: "USDC" | "native-currency") => {
     if (!isSolanaWallet || !selectedWallet) {
       showErrorToast("Please select a Solana wallet");
       return;
     }
     try {
-      fundWalletSolana(selectedWallet.address, {
+      await fundWalletSolana(selectedWallet.address, {
         amount: "1",
         ...(asset && { asset }),
       });


### PR DESCRIPTION
## Description 

While trying the example with a new app (without enabling account funding), I noticed the `Fund <currency>` buttons did nothing, while throwing an uncaught error:
<img width="437" height="83" alt="UncaughtError" src="https://github.com/user-attachments/assets/d0e758d7-b930-4677-a882-249c036ffe01" />
This is because the current `try catch` block does not catch async errors. I followed the pattern in [`create-a-wallet.tsx`](https://github.com/privy-io/examples/blob/81b7cac976699aabe3574f6eca3ff22a03465cbf/privy-react-starter/src/components/sections/create-a-wallet.tsx#L40-L50) and made the handlers `async` so that we can `await` before the `fundWallet` API call. 

### Alternative fix

The alternative way to fix this would be to `.catch` the error as a callback:
```tsx
fundWalletEvm(selectedWallet.address, {
        amount: "1",
        ...(asset && { asset }),
      }).catch((error) => {
        console.log(error);
        showErrorToast("Failed to fund wallet. Please try again.");
      });
```
However, this does not match handlers from other files.

## Testing 

The error is now caught and the toast appears correctly:
<img width="434" height="52" alt="RegularError" src="https://github.com/user-attachments/assets/f693f2a9-53ca-4386-b1e1-8f92a239af7c" />
<img width="403" height="83" alt="ErrorToast" src="https://github.com/user-attachments/assets/4107fa31-97e3-4545-95fa-83520b9f8707" />

The funding modal also appears correctly once funding is enabled in the dashboard:
<img width="376" height="381" alt="FundingModal" src="https://github.com/user-attachments/assets/dcd6f3ed-ffc1-437f-9e20-212783972954" />

