### PR TITLE
chore: remove unused provider in example

### DIFF
--- a/examples/privy-next-tempo/src/providers/PrivyProvider.tsx
+++ b/examples/privy-next-tempo/src/providers/PrivyProvider.tsx
@@ -32,11 +32,3 @@ export function PrivyProvider({ children }: { children: React.ReactNode }) {
     </BasePrivyProvider>
   );
 }
-
-function ViemProvider({ children }: { children: React.ReactNode }) {
-  const [client, setClient] = useState();
-
-  useEffect(() => {}, []);
-
-  return <>{children}</>;
-}


### PR DESCRIPTION
Removes unused `ViemProvider` in provider