### PR TITLE
Update to use useSigners hook in next.js example

### DIFF
--- a/privy-next-starter/.env.example
+++ b/privy-next-starter/.env.example
@@ -1,4 +1,8 @@
 NEXT_PUBLIC_PRIVY_APP_ID=your-privy-app-id
-NEXT_PUBLIC_PRIVY_SIGNER_ID=your-signer-id
-# Uncomment and change if you are using Solana
+
+# Optional: Only needed for the Signers feature (server-side wallet access)
+# Create a key quorum in Privy Dashboard > Wallet infrastructure > Authorization keys
+# NEXT_PUBLIC_PRIVY_SIGNER_ID=your-key-quorum-id
+
+# Optional: Custom Solana RPC URL
 # NEXT_PUBLIC_SOLANA_MAINNET_RPC_URL=your-solana-mainnet-rpc

--- a/privy-next-starter/README.md
+++ b/privy-next-starter/README.md
@@ -28,15 +28,19 @@ Copy the example environment file and configure your Privy app credentials:
 cp .env.example .env.local
 ```
 
-Update `.env.local` with your Privy app credentials:
+Update `.env.local` with your Privy app ID:
 
 ```env
-# Public - Safe to expose in the browser
 NEXT_PUBLIC_PRIVY_APP_ID=your_app_id_here
-NEXT_PUBLIC_PRIVY_SIGNER_ID=your_signer_id_here
 ```
 
-**Important:** Variables prefixed with `NEXT_PUBLIC_` are exposed to the browser. Get your credentials from the [Privy Dashboard](https://dashboard.privy.io).
+Get your App ID from the [Privy Dashboard](https://dashboard.privy.io).
+
+**Optional:** To use the Signers feature (server-side wallet access), create a key quorum in **Dashboard > Wallet infrastructure > Authorization keys** and add:
+
+```env
+NEXT_PUBLIC_PRIVY_SIGNER_ID=your_key_quorum_id_here
+```
 
 ### 4. Start Development Server
 

--- a/privy-next-starter/src/app/page.tsx
+++ b/privy-next-starter/src/app/page.tsx
@@ -13,7 +13,7 @@ import FundWallet from "@/components/sections/fund-wallet";
 import LinkAccounts from "@/components/sections/link-accounts";
 import UnlinkAccounts from "@/components/sections/unlink-accounts";
 import WalletActions from "@/components/sections/wallet-actions";
-import SessionSigners from "@/components/sections/session-signers";
+import Signers from "@/components/sections/signers";
 import WalletManagement from "@/components/sections/wallet-management";
 import MFA from "@/components/sections/mfa";
 
@@ -39,7 +39,7 @@ function Home() {
               <LinkAccounts />
               <UnlinkAccounts />
               <WalletActions />
-              <SessionSigners />
+              <Signers />
               <WalletManagement />
               <MFA />
             </div>

--- a/privy-next-starter/src/components/sections/signers.tsx
+++ b/privy-next-starter/src/components/sections/signers.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo, useEffect } from "react";
-import { useSessionSigners, useWallets } from "@privy-io/react-auth";
+import { useSigners, useWallets } from "@privy-io/react-auth";
 import Section from "../reusables/section";
 import { showSuccessToast, showErrorToast } from "@/components/ui/custom-toast";
 
@@ -11,9 +11,9 @@ type WalletInfo = {
   name: string;
 };
 
-const SessionSigners = () => {
+const Signers = () => {
   const { wallets } = useWallets();
-  const { addSessionSigners, removeSessionSigners } = useSessionSigners();
+  const { addSigners, removeSigners } = useSigners();
 
   const allWallets = useMemo((): WalletInfo[] => {
     return wallets.map((wallet) => ({
@@ -31,64 +31,68 @@ const SessionSigners = () => {
     }
   }, [allWallets, selectedWallet]);
 
-  const handleAddSessionSigners = async () => {
+  const handleAddSigners = async () => {
     if (!selectedWallet) {
       showErrorToast("Please select a wallet");
       return;
     }
+    if (!process.env.NEXT_PUBLIC_PRIVY_SIGNER_ID) {
+      showErrorToast("NEXT_PUBLIC_PRIVY_SIGNER_ID not configured");
+      return;
+    }
     try {
-      await addSessionSigners({
+      await addSigners({
         address: selectedWallet.address,
         signers: [
           {
-            signerId: process.env.NEXT_PUBLIC_PRIVY_SIGNER_ID!,
+            signerId: process.env.NEXT_PUBLIC_PRIVY_SIGNER_ID,
             policyIds: [],
           },
         ],
       });
-      showSuccessToast("Session signer added");
+      showSuccessToast("Signer added");
     } catch (error) {
-      const message = error?.toString?.() ?? "Failed to add session signer";
+      const message = error?.toString?.() ?? "Failed to add signer";
       showErrorToast(message);
     }
   };
 
-  const handleRemoveSessionSigners = async () => {
+  const handleRemoveSigners = async () => {
     if (!selectedWallet) {
       showErrorToast("Please select a wallet");
       return;
     }
     try {
-      await removeSessionSigners({
+      await removeSigners({
         address: selectedWallet.address,
       });
-      showSuccessToast("Session signer removed");
+      showSuccessToast("Signer removed");
     } catch (error) {
-      const message = error?.toString?.() ?? "Failed to remove session signer";
+      const message = error?.toString?.() ?? "Failed to remove signer";
       showErrorToast(message);
     }
   };
 
   const availableActions = [
     {
-      name: "Add session signer",
-      function: handleAddSessionSigners,
+      name: "Add signer",
+      function: handleAddSigners,
       disabled: !selectedWallet,
     },
     {
-      name: "Remove session signer",
-      function: handleRemoveSessionSigners,
+      name: "Remove signer",
+      function: handleRemoveSigners,
       disabled: !selectedWallet,
     },
   ];
 
   return (
     <Section
-      name="Session signers"
+      name="Signers"
       description={
-        "Delegate signing to a trusted service for actions like limit orders or scheduled transactions when the user is offline."
+        "Delegate signing to a trusted server for actions like limit orders or scheduled transactions when the user is offline. Requires a key quorum ID from your Privy Dashboard."
       }
-      filepath="src/components/sections/session-signers"
+      filepath="src/components/sections/signers"
       actions={availableActions}
     >
       <div className="mb-4">
@@ -144,4 +148,4 @@ const SessionSigners = () => {
   );
 };
 
-export default SessionSigners;
+export default Signers;


### PR DESCRIPTION
- Rename session-signers.tsx to signers.tsx
- Replace useSessionSigners with useSigners (deprecated API)
- Replace addSessionSigners/removeSessionSigners with addSigners/removeSigners
- Make NEXT_PUBLIC_PRIVY_SIGNER_ID optional with better documentation
- Add validation for missing signer ID before attempting to add signers

Note: Code generated using Claude -- please review.