### PR TITLE
fix: update admin wallet ID env var

### DIFF
--- a/examples/privy-next-yield-demo/.env.local.example
+++ b/examples/privy-next-yield-demo/.env.local.example
@@ -4,7 +4,7 @@ PRIVY_APP_SECRET=your-privy-app-secret
 
 # Vault Configuration
 NEXT_PUBLIC_VAULT_ID=your-vault-id
-NEXT_PUBLIC_FEE_RECIPIENT=0x...fee-recipient-address
+NEXT_PUBLIC_ADMIN_WALLET_ID=your-admin-wallet-id
 
 # Webhook (optional — for real-time transaction status updates)
 PRIVY_WEBHOOK_SECRET=your-privy-webhook-secret

--- a/examples/privy-next-yield-demo/README.md
+++ b/examples/privy-next-yield-demo/README.md
@@ -44,8 +44,8 @@ NEXT_PUBLIC_VAULT_ID=your-vault-id
 # Webhook Secret (for transaction updates)
 PRIVY_WEBHOOK_SECRET=your-webhook-secret
 
-# Optional: Fee Recipient Address (for display purposes)
-NEXT_PUBLIC_FEE_RECIPIENT=0x...
+# Privy Admin Wallet (not relevant if you are using an external wallet)
+NEXT_PUBLIC_ADMIN_WALLET_ID=your-admin-wallet-id
 ```
 
 Get your Privy credentials from [dashboard.privy.io](https://dashboard.privy.io).
@@ -115,7 +115,7 @@ The app uses the **Privy Home** design system with:
 
 ## Learn More
 
-- [Privy Documentation](https://docs.privy.io)
+- [Privy Documentation](https://docs.privy.io/transaction-management/earn/overview)
 - [Privy Yield API](https://docs.privy.io/guide/yield)
 - [Morpho Protocol](https://morpho.org)
 - [Base Network](https://base.org)

--- a/examples/privy-next-yield-demo/src/app/app-dashboard/page.tsx
+++ b/examples/privy-next-yield-demo/src/app/app-dashboard/page.tsx
@@ -11,14 +11,14 @@ import { FeeRecipientCard } from "@/components/FeeRecipientCard";
 import { TransactionHistory } from "@/components/TransactionHistory";
 import { FullScreenLoader } from "@/components/ui/fullscreen-loader";
 import { Header } from "@/components/ui/header";
-import { getFeeRecipientWalletId } from "@/lib/constants";
+import { getAdminWalletId } from "@/lib/constants";
 
 export default function AppDashboard() {
   const { ready, authenticated, logout } = usePrivy();
   const router = useRouter();
   const [refreshKey, setRefreshKey] = useState(0);
 
-  const feeRecipientWalletId = getFeeRecipientWalletId();
+  const adminWalletId = getAdminWalletId();
 
   useEffect(() => {
     if (ready && !authenticated) {
@@ -55,11 +55,11 @@ export default function AppDashboard() {
           <div className="lg:col-span-2 space-y-6">
             <PositionDisplay
               key={`position-${refreshKey}`}
-              walletId={feeRecipientWalletId}
+              walletId={adminWalletId}
             />
             <TransactionHistory
               refreshKey={refreshKey}
-              walletId={feeRecipientWalletId}
+              walletId={adminWalletId}
             />
             <FeeRecipientCard />
           </div>

--- a/examples/privy-next-yield-demo/src/components/AppWalletCard.tsx
+++ b/examples/privy-next-yield-demo/src/components/AppWalletCard.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { createPublicClient, http, formatUnits } from 'viem';
 import { base } from 'viem/chains';
-import { USDC_ADDRESS, USDC_DECIMALS, truncateAddress, getFeeRecipientWalletId } from '@/lib/constants';
+import { USDC_ADDRESS, USDC_DECIMALS, truncateAddress, getAdminWalletId } from '@/lib/constants';
 
 const publicClient = createPublicClient({
   chain: base,
@@ -26,18 +26,18 @@ export function AppWalletCard() {
   const [isLoading, setIsLoading] = useState(true);
   const [copied, setCopied] = useState(false);
 
-  const feeRecipientWalletId = getFeeRecipientWalletId();
+  const adminWalletId = getAdminWalletId();
 
   // Resolve the on-chain address from the Privy wallet ID
   useEffect(() => {
     async function resolveAddress() {
-      if (!feeRecipientWalletId) {
+      if (!adminWalletId) {
         setIsLoading(false);
         return;
       }
 
       try {
-        const res = await fetch(`/api/wallet-address?wallet_id=${feeRecipientWalletId}`);
+        const res = await fetch(`/api/wallet-address?wallet_id=${adminWalletId}`);
         if (!res.ok) throw new Error('Failed to resolve wallet address');
         const data = await res.json();
         setWalletAddress(data.address);
@@ -48,7 +48,7 @@ export function AppWalletCard() {
     }
 
     resolveAddress();
-  }, [feeRecipientWalletId]);
+  }, [adminWalletId]);
 
   // Fetch USDC balance once address is resolved
   useEffect(() => {

--- a/examples/privy-next-yield-demo/src/components/AppWithdrawForm.tsx
+++ b/examples/privy-next-yield-demo/src/components/AppWithdrawForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { parseUSDC, getVaultId, getFeeRecipientWalletId } from '@/lib/constants';
+import { parseUSDC, getVaultId, getAdminWalletId } from '@/lib/constants';
 
 type WithdrawStatus = 'idle' | 'loading' | 'success' | 'error';
 
@@ -24,7 +24,7 @@ export function AppWithdrawForm({ onSuccess }: { onSuccess?: () => void }) {
   const [error, setError] = useState<string | null>(null);
   const [txResult, setTxResult] = useState<WithdrawResponse | null>(null);
 
-  const walletId = getFeeRecipientWalletId();
+  const walletId = getAdminWalletId();
   const vaultId = getVaultId();
 
   const handleWithdraw = async (e: React.FormEvent) => {
@@ -102,7 +102,7 @@ export function AppWithdrawForm({ onSuccess }: { onSuccess?: () => void }) {
 
         {!walletId && (
           <p className="text-sm text-[#906218] bg-[#FEF3C7] p-3 rounded-lg">
-            Fee recipient wallet ID not configured. Set NEXT_PUBLIC_FEE_RECIPIENT_WALLET_ID in your environment.
+            Admin wallet ID not configured. Set NEXT_PUBLIC_ADMIN_WALLET_ID in your environment.
           </p>
         )}
 

--- a/examples/privy-next-yield-demo/src/lib/constants.ts
+++ b/examples/privy-next-yield-demo/src/lib/constants.ts
@@ -12,7 +12,7 @@ export const PRIVY_API_URL = 'https://api.privy.io/v1';
 
 // Environment variables (set these in .env.local)
 export const getVaultId = () => process.env.NEXT_PUBLIC_VAULT_ID || '';
-export const getFeeRecipientWalletId = () => process.env.NEXT_PUBLIC_FEE_RECIPIENT_WALLET_ID || '';
+export const getAdminWalletId = () => process.env.NEXT_PUBLIC_ADMIN_WALLET_ID || '';
 
 // Format USDC amount for display (from smallest unit to human readable)
 export function formatUSDC(amount: string | bigint): string {


### PR DESCRIPTION
### TL;DR

Renamed fee recipient configuration to admin wallet configuration throughout the Privy Next.js yield demo application.

### What changed?

- Renamed environment variable from `NEXT_PUBLIC_FEE_RECIPIENT` to `NEXT_PUBLIC_ADMIN_WALLET_ID`
- Updated function name from `getFeeRecipientWalletId()` to `getAdminWalletId()`
- Changed variable names from `feeRecipientWalletId` to `adminWalletId` across components
- Updated error messages and comments to reference admin wallet instead of fee recipient
- Modified documentation link to point to the transaction management earn overview