### PR TITLE
fix: use selected wallet in Solana sign example

### DIFF
--- a/examples/privy-next-solana/src/components/sections/wallet-actions.tsx
+++ b/examples/privy-next-solana/src/components/sections/wallet-actions.tsx
@@ -170,7 +170,7 @@ const WalletActions = () => {
 
       const solTransferInstruction = getTransferSolInstruction({
         amount: 1000000,
-        destination: address("Enter_Destination_Address_Here"),
+        destination: address(selectedWallet.address),
         source: createNoopSigner(address(selectedWallet.address)),
       });
 


### PR DESCRIPTION
## Summary

- Replaces the placeholder Solana destination address in the sign-transaction example with the currently selected wallet address.
- Aligns the sign flow with the send flow, which already self-transfers to the selected wallet in the demo.
- Prevents the example from throwing before `signTransactionSolana` is reached when users click the action without editing source code first.

## Validation

From `examples/privy-next-solana`:

- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec eslint src/components/sections/wallet-actions.tsx`
- `git diff --check`

Also ran `corepack pnpm build`; compilation and type/lint phases passed, then prerendering failed because this local environment does not provide a valid `NEXT_PUBLIC_PRIVY_APP_ID`:

```text
Error: Cannot initialize the Privy provider with an invalid Privy app ID
```
