### PR TITLE
chore: update pinata template to use device authorization flow

### DIFF
--- a/examples/pinata-template/README.md
+++ b/examples/pinata-template/README.md
@@ -13,8 +13,8 @@ Ethereum and Solana via the Privy Agent CLI.
 ## Setup
 
 1. Deploy this template
-2. Run `pnpm dlx @privy-io/agent-wallet-cli login --non-interactive`
-3. Complete browser authentication and paste the credentials blob back to the agent
+2. Run `pnpm dlx @privy-io/agent-wallet-cli login`
+3. Complete the browser authentication flow
 4. Fund your wallet by running `pnpm dlx @privy-io/agent-wallet-cli fund`
 
 ## Commands

--- a/examples/pinata-template/manifest.json
+++ b/examples/pinata-template/manifest.json
@@ -17,9 +17,7 @@
   },
   "scripts": {
     "build": "npm install -g @privy-io/agent-wallet-cli",
-    "start": "privy-agent-wallet login --non-interactive"
+    "start": "privy-agent-wallet login"
   },
-  "routes": [
-    { "path": "/dashboard", "port": 3000, "protected": false }
-  ]
+  "routes": [{ "path": "/dashboard", "port": 3000, "protected": false }]
 }

--- a/examples/pinata-template/workspace/TOOLS.md
+++ b/examples/pinata-template/workspace/TOOLS.md
@@ -1,15 +1,17 @@
 # Tools
 
 ## Terminal
+
 You can run shell commands using `pnpm dlx @privy-io/agent-wallet-cli`.
 Use this to log in, list wallets, fund wallets, sign messages, and send transactions.
 
 ## Privy Agent Wallet CLI
+
 Your primary tool for all wallet operations. Key commands:
 
 - **Login**: Authenticate and create a session with Ethereum and Solana wallets
   ```bash
-  pnpm dlx @privy-io/agent-wallet-cli login --non-interactive
+  pnpm dlx @privy-io/agent-wallet-cli login
   ```
 - **List wallets**: Show wallet addresses and IDs for the current session
   ```bash
@@ -29,6 +31,7 @@ Your primary tool for all wallet operations. Key commands:
   ```
 
 ## Paid HTTP Requests
+
 Make requests to APIs that require payment using x402 or MPP protocols.
 The CLI automatically handles payment from the agent wallet on a 402 response.
 
@@ -42,4 +45,5 @@ The CLI automatically handles payment from the agent wallet on a 402 response.
   ```
 
 ## Agent Sandbox
+
 Users can monitor all wallet activity, manage funds, and revoke agent access at https://agents.privy.io.


### PR DESCRIPTION
## Summary

The Privy agent wallet CLI has been updated to use a device authorization flow. The pinata template still referenced the old `--non-interactive` flag and instructed users to paste a credentials blob back to the agent — both of which no longer apply.

- Remove `--non-interactive` flag from `manifest.json` start script, `README.md` setup step, and `workspace/TOOLS.md` login command
- Replace the "paste the credentials blob back to the agent" step with "Complete the browser authentication flow"