### PR TITLE
chore(privy-next-cards): update for the current card component APIs

### DIFF
--- a/examples/privy-next-cards/.env.example
+++ b/examples/privy-next-cards/.env.example
@@ -1,5 +1,13 @@
 NEXT_PUBLIC_PRIVY_APP_ID=your-privy-app-id
 
+# Optional. Only needed to sign up for a card in PRODUCTION. `SignUpForCardView` requires the
+# on-chain spend-approval target on production — the mainnet USDC contract and the Bridge spender
+# that pulls from it — because the SDK only ships built-in targets for sandbox testnets. Get both
+# from the Bridge production integration behind your app's card configuration. Leave them blank to
+# run sandbox only; production signup stays disabled until both are set.
+NEXT_PUBLIC_CARD_USDC_ADDRESS=
+NEXT_PUBLIC_CARD_SPENDER_ADDRESS=
+
 # Optional. Only needed for the "Simulate a purchase" button, which calls Stripe Issuing's test
 # helpers from a route handler. Must be a TEST-mode key (sk_test_… or rk_test_…) for the same Stripe
 # account that issues the cards. Server-only — never prefix this with NEXT_PUBLIC_.

--- a/examples/privy-next-cards/README.md
+++ b/examples/privy-next-cards/README.md
@@ -4,24 +4,32 @@ This Next.js example shows how to issue and manage cards for your users with the
 
 It is scaffolded from [`privy-next-starter`](../../privy-next-starter), trimmed down to just the card flow — the wallet, funding, linking, signer, and MFA sections are intentionally removed (opted out under `sectionOverrides` in [`.sync-manifest.json`](../../.sync-manifest.json), so base syncs don't re-add them).
 
-> **⚠️ A card cannot spend in production yet.** `SignUpForCardView` grants the card's USDC spend allowance to a Bridge spender address, and the SDK only publishes those addresses for sandbox testnets. In production it skips the approval and still reports the card as ready, so the card exists with no allowance behind it. Both environments are available in the demo's toggle — see [Environments](#environments).
+> **⚠️ Production signup needs a spend-approval target.** `SignUpForCardView` grants the card's USDC spend allowance to a Bridge spender. The SDK ships built-in targets for sandbox testnets, but not for mainnets — on `environment="production"` it requires a `spendApproval` prop naming the USDC contract and Bridge spender to approve. This demo reads both from env vars and keeps production signup disabled until they are set. See [Environments](#environments).
 
 ## Flow
 
 1. Sign in with Privy. The provider creates an embedded Ethereum wallet for users without one.
-2. Press **Sign up for a card**. `SignUpForCardView` walks the e-sign disclosure, the bank agreements, Bridge terms, and KYC, then creates the card and prompts for the on-chain USDC spend approval.
+2. Press **Sign up for a card**. `SignUpForCardView` walks the e-sign disclosure, the bank agreements (which name your app, the issuing bank, and Bridge as the card-program manager), the provider terms, and KYC, then creates the card and prompts for the on-chain USDC spend approval.
 3. On success it fires `onCardReady` with the card id, and the demo hands straight off to the summary.
-4. `CardSummaryView` shows the balance, card face, transactions, card details and reveal, and statement downloads.
+4. `CardSummaryView` shows the balance, card face, transactions, card details and reveal, statement downloads, and the freeze/cancel/replace actions.
 5. Optionally press **Simulate a $0.50 purchase** to put a real row on the transaction list. See [Simulating a purchase](#simulating-a-purchase).
 
-A pill next to the funding wallet address shows whether a card exists yet. The demo finds an existing card by listing the user's cards for the selected environment, so a reload goes straight to the summary. A returning user who runs signup again still starts at "Get started", but the SDK reuses the existing card rather than creating a second one (one card per account).
+A pill next to the funding wallet address shows whether a card exists yet. The demo finds an existing card by listing the user's cards for the selected environment, so a reload goes straight to the summary.
+
+**Sign up for a card** stays available even once a card exists, so the onboarding flow is always there to walk through. A returning user starts at "Get started" again and re-walks the disclosure and KYC steps, but the SDK hands back the card they already have rather than issuing a second one. To get a genuinely new card, use **Replace** in the card details.
+
+### Replacements
+
+**Replace** in the card details closes the current card and issues a new one in a single call, carrying the reason the user picked. `CardSummaryView` does not adopt the replacement — the open panel is scoped to the card that just closed, so it shows a "card cancelled" banner and reports the new card id through `onReplaced`. This demo points its card id at the replacement and keys the view on it, so the panel remounts on the new card.
+
+Because a replacement leaves the old card behind as `canceled`, a user accumulates cards. The list endpoint returns them newest first and includes cancelled ones, so the demo picks the newest card whose `status` isn't `canceled` (see [`cards-api.ts`](./src/components/sections/cards-api.ts)).
 
 ## Source map
 
 - [`src/app/page.tsx`](./src/app/page.tsx): Login state, page layout, and the `Cards` section
 - [`src/providers/providers.tsx`](./src/providers/providers.tsx): Privy provider configuration; EVM-only, creates an embedded Ethereum wallet on login
-- [`src/components/sections/cards.tsx`](./src/components/sections/cards.tsx): Hosts both card views, owns the environment toggle and card id, and holds the chain map and developer name
-- [`src/components/sections/cards-api.ts`](./src/components/sections/cards-api.ts): Lists the user's cards for an environment, since the SDK exports no card-list hook
+- [`src/components/sections/cards.tsx`](./src/components/sections/cards.tsx): Hosts both card views, owns the environment toggle and card id, and holds the chain map and the production spend-approval target
+- [`src/components/sections/cards-api.ts`](./src/components/sections/cards-api.ts): Lists the user's cards for an environment and picks the newest open one, since the SDK exports no card-list hook
 - [`src/components/sections/find-embedded-wallet.ts`](./src/components/sections/find-embedded-wallet.ts): Picks the embedded EVM wallet whose Privy wallet id the card views need
 - [`src/components/sections/modal.tsx`](./src/components/sections/modal.tsx): Centered 440px modal the card views render inside
 - [`src/components/sections/simulate-spend.ts`](./src/components/sections/simulate-spend.ts): Resolves the Privy card id to its Stripe card id, then calls the test-spend route
@@ -67,6 +75,7 @@ In the [Privy dashboard](https://dashboard.privy.io), configure the app used by 
 - Enable embedded wallets.
 - Enable cards for the app.
 - Save the app's Stripe publishable key in the cards config. `CardSummaryView` fetches it itself from `GET /api/v1/apps/:app_id/cards/config` — there is no key prop. If it is missing, **Show details** stays silently inert.
+- Set the app's **legal name** on the card design. `CardSummaryView`'s footer disclosure names your legal entity as the Platform Provider and reads it from the app config — there is no `developerName` prop. It falls back to the app's display name when no legal name is set, so an app that skips this ships the display name in regulatory copy.
 - Make sure the Bridge **sandbox** account behind the app's card configuration has the `cards` endorsement. Sandbox and production are separate Bridge accounts with separate capabilities, so enabling cards in production does not cover sandbox. Without it, signup fails with `'cards' endorsement not allowed — Cards is not enabled on the developer account`, which no amount of retrying or KYC will clear.
 
 ### 5. Fund the wallet
@@ -90,15 +99,25 @@ Production needs its own credentials, separate from sandbox: a Bridge production
 |  | Sandbox | Production |
 | --- | --- | --- |
 | Funding chain | Base Sepolia (`eip155:84532`) | Base (`eip155:8453`), real USDC |
-| Card signup | ✅ | ✅ |
+| Spend approval target | built in | `spendApproval` prop, from env |
+| Card signup | ✅ | ✅ once the target is set |
 | Card summary | ✅ | ✅ |
 | Simulated purchase | ✅ | ❌ not possible |
 
-**A production card cannot spend yet.** `SignUpForCardView` grants the card's USDC allowance to a Bridge spender, and the SDK publishes those addresses for sandbox testnets only. In production it skips the approval and still reports the card `ready`, so the card exists but has no allowance behind it. Production signup is still enabled so you can exercise the real onboarding path — live Bridge customer, real KYC, real Stripe card — and the demo says so on screen. Spend starts working once mainnet spenders ship, with no change needed here.
+**Production needs the spend-approval target.** `SignUpForCardView`'s props are discriminated on `environment`: sandbox resolves the USDC contract and Bridge spender from the SDK's built-in testnet targets and rejects a supplied one, while production **requires** a `spendApproval` — Bridge does not publish its mainnet targets to the SDK, and approving the wrong spender would leave a `ready` card that cannot spend. Passing neither, or passing one on sandbox, is a type error rather than a silently unusable card.
+
+This demo reads the production target from two public env vars and gates signup on them:
+
+```env
+NEXT_PUBLIC_CARD_USDC_ADDRESS=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913
+NEXT_PUBLIC_CARD_SPENDER_ADDRESS=0x…
+```
+
+The USDC address is Base mainnet's; the spender is the issuer address from the Bridge **production** integration behind your app's card configuration. With either missing, the production **Sign up for a card** button is disabled and the modal says which vars to set. Sandbox is unaffected and needs no configuration.
+
+`SignUpForCardView` also accepts a Solana target (`{stablecoinAddress, programId, merchantId}`) for a `solana:*` `chainId`; this demo is EVM-only, so it always supplies the EVM shape.
 
 **Why simulated purchases are sandbox-only.** Stripe's Issuing test helpers do not exist for live keys — there is no API to fabricate a live authorization, so live spend must be a real purchase at a real merchant. The button is hidden in production, and the route refuses non-test keys.
-
-Production mode needs its own credentials, separate from sandbox: a Bridge **production** integration with the `cards` endorsement on that live account, and a **live** Stripe key in the app's production card configuration. Sandbox credentials do not carry over.
 
 ## Simulating a purchase
 
@@ -120,15 +139,15 @@ Notes:
 
 ## SDK version
 
-`CardSummaryView` and `SignUpForCardView` are not in a stable `@privy-io/react-auth` release yet, so this example pins the beta that contains both.
+`CardSummaryView` and `SignUpForCardView` are not in a stable `@privy-io/react-auth` release yet, so this example pins the beta that contains both. Their props are still moving, so the pin is exact rather than a caret range — a newer beta can be a breaking change.
 
 To check what you actually have installed:
 
 ```bash
-rg 'SignUpForCardView|CardSummaryView' node_modules/@privy-io/react-auth/dist/dts/ui.d.ts
+rg 'SignUpForCardView|CardSummaryView|spendApproval|onReplaced|developerName' node_modules/@privy-io/react-auth/dist/dts/ui.d.ts
 ```
 
-Both names must appear. If you swap in a locally built tarball to test unreleased SDK changes, note that a local build and a published release can share a version string with different contents, so a later `pnpm install` can silently replace it with no resolution error — run the check above again after any install. Don't commit a `file:` dependency; it is machine-local.
+Both component names must appear, `spendApproval` and `onReplaced` must appear, and `developerName` must not — that combination is the beta this example is written against. An older beta fails `tsc` on all three. If you swap in a locally built tarball to test unreleased SDK changes, note that a local build and a published release can share a version string with different contents, so a later `pnpm install` can silently replace it with no resolution error — run the check above again after any install. Don't commit a `file:` dependency; it is machine-local.
 
 ## Relevant links
 

--- a/examples/privy-next-cards/package.json
+++ b/examples/privy-next-cards/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
-    "@privy-io/react-auth": "3.38.0-beta-20260821205628",
+    "@privy-io/react-auth": "3.39.0-beta-20260826194301",
     "next": "15.5.7",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/examples/privy-next-cards/pnpm-lock.yaml
+++ b/examples/privy-next-cards/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0(react@19.1.0)
       '@privy-io/react-auth':
-        specifier: 3.38.0-beta-20260821205628
-        version: 3.38.0-beta-20260821205628(@solana-program/memo@0.8.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@stripe/stripe-js@1.54.2)(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@3.25.76)
+        specifier: 3.39.0-beta-20260826194301
+        version: 3.39.0-beta-20260826194301(@solana-program/memo@0.8.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@stripe/stripe-js@1.54.2)(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@3.25.76)
       next:
         specifier: 15.5.7
         version: 15.5.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -676,8 +676,8 @@ packages:
   '@privy-io/api-types@0.20.0':
     resolution: {integrity: sha512-CqzPGb4xj2jJC07UiBhbdBf7a02UhI047IVu2rr6EP5xImhR0iD2aSxCbjVo9fx07TNM6Sv/O14Dcrqc96c8uw==}
 
-  '@privy-io/are-addresses-equal@0.0.11':
-    resolution: {integrity: sha512-KsvoquDTXAwCykRtxWRrLLRF5OrmBRm9MZSgMYM/rB/J3yWUrZhOARtiFelgs92Rn/JnTkDNA0iC9YenjIvaCA==}
+  '@privy-io/are-addresses-equal@0.0.12-beta-20260826194301':
+    resolution: {integrity: sha512-2i9NBus2tFGKP2bQsuA2R4VdrosmfAm2TtSF2ksHn/zVzF8Uq2ihM0b3g7zuWpCBiIzJEakdoM1emDSOnXq60A==}
 
   '@privy-io/chains@0.5.2':
     resolution: {integrity: sha512-h6Zr9hOFNdZamiv/XuFPPJwaMeoWJBOPCqSczr12Nh731tYHhCdCXr5RG+1WvCowbvj3xCXWokkAlByxnU2xsw==}
@@ -685,13 +685,13 @@ packages:
   '@privy-io/encoding@0.2.2':
     resolution: {integrity: sha512-bQHM5AB+F3/MIEaJ0WcFbCqAyuls7nUbQ34AlyctibPK1tmYL0tc9D2voeHo9q2S31nlgIKLEDJ65VZc+pcv6Q==}
 
-  '@privy-io/ethereum@0.2.2':
-    resolution: {integrity: sha512-tKA8qqkPJpsOq2vKLj0CH7kXbwtSn19PrpWLdlcDoBHCSyZyEnKqDspO9IsliCcagREBtmn3QthzBWoJKbaPLA==}
+  '@privy-io/ethereum@0.2.3-beta-20260826194301':
+    resolution: {integrity: sha512-jU/fdjTXukedLU/5y7xmLPNog2Tz6IsJpw5hQ96aQ3kTFhW/Mv7EnXbV9yU4tiTgngSYHBrPKmg+K+6/bZRCdA==}
     peerDependencies:
-      viem: 2.55.10
+      viem: 2.55.15
 
-  '@privy-io/js-sdk-core@0.72.0-beta-20260821205628':
-    resolution: {integrity: sha512-JRxlmesVqkC332R0HhpXdQzPTkw6wI9jZPRi2sTcsmo5Yu76iNX0ysm2jpmlPn5TfL+90vFwKFikN59szQCDlg==}
+  '@privy-io/js-sdk-core@0.72.1-beta-20260826194301':
+    resolution: {integrity: sha512-Xr3xTPJwh7yNUBHlQ4bYlVeAUnTFU1Zi45M881WPvFzKtw1Ko7FCvsIxY+ZHG3unR2Gu6gGaWmwIItDMR+iciw==}
     peerDependencies:
       permissionless: ^0.2.47
       viem: 2.55.15
@@ -704,8 +704,8 @@ packages:
   '@privy-io/popup@0.0.5':
     resolution: {integrity: sha512-lIwErJA86rHmLkSyapv86Z6hVzoLl544iZsVgk4tcVCHxbLBlLI4UmgLDmviNTZdp+uY0VEZe8fjUQIPpa6tZg==}
 
-  '@privy-io/react-auth@3.38.0-beta-20260821205628':
-    resolution: {integrity: sha512-UMSOy2NSUqYaGS0sNAcfnOnYcS88BUOkLSRYdyTDLqJwy1hpVGaJV/vY0zII/XD5pZ0iNo1aqix/Choo9XvSEQ==}
+  '@privy-io/react-auth@3.39.0-beta-20260826194301':
+    resolution: {integrity: sha512-PH/B77BX4OagKFt88XbFKtPkDZ64WQJzfJVSOq0fCPGJXqdk147oHyw7Fr77bIKPXJmOlI93O3S3fZBpj9X27g==}
     peerDependencies:
       '@abstract-foundation/agw-client': ^1.0.0
       '@farcaster/mini-app-solana': ^1.0.0
@@ -732,8 +732,8 @@ packages:
       permissionless:
         optional: true
 
-  '@privy-io/routes@0.2.11':
-    resolution: {integrity: sha512-dOB5lo72SAgjZPqCYxGNy4Jjm/T3PgTlW7M7DDQ6O6tbloVawX5rH4qzIfSCL4OdAFpDdjueNmCgtc6CT+G+EA==}
+  '@privy-io/routes@0.2.12':
+    resolution: {integrity: sha512-jLidE/l+OGjzMvDeV+tIGASQGblIYaqBNYHLlpNKEBspmUdfU5EM/BBT9WyphtNhVelsGyX3jIxW5PukqC6b7Q==}
 
   '@privy-io/urls@0.0.5':
     resolution: {integrity: sha512-cy4SQY60I9aGm+Er/gL4P+Rrsw2B7RoD6GKw5ZlwEN3jCm3tfclWeZI+xlJSKIwIu71YV9fWpO0bjLTs0tMLgQ==}
@@ -3939,14 +3939,6 @@ packages:
       typescript:
         optional: true
 
-  viem@2.55.10:
-    resolution: {integrity: sha512-Q9Ba+/ma81U2M5o5P2AQ7Ux8rTIwmCZvUcr8rKdQ22bV0IBFHllM2m5gWDP8hFaUN2nH2oW3QG44amRazflYNQ==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   viem@2.55.15:
     resolution: {integrity: sha512-ka9SfSJ3ZfhuUEzTGmufwALRvEPVKM068tF0AwfdRZagqA3yuFa/QoXIvALzr9y47m4Wiisl3yEoYWuFQso6Ng==}
     peerDependencies:
@@ -4909,9 +4901,9 @@ snapshots:
 
   '@privy-io/api-types@0.20.0': {}
 
-  '@privy-io/are-addresses-equal@0.0.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@privy-io/are-addresses-equal@0.0.12-beta-20260826194301(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      viem: 2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -4924,18 +4916,18 @@ snapshots:
     dependencies:
       '@scure/base': 1.2.6
 
-  '@privy-io/ethereum@0.2.2(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@privy-io/ethereum@0.2.3-beta-20260826194301(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
       viem: 2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
 
-  '@privy-io/js-sdk-core@0.72.0-beta-20260821205628(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@privy-io/js-sdk-core@0.72.1-beta-20260826194301(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
       '@privy-io/api-base': 1.9.5
       '@privy-io/api-types': 0.20.0
       '@privy-io/chains': 0.5.2
       '@privy-io/encoding': 0.2.2
-      '@privy-io/ethereum': 0.2.2(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
-      '@privy-io/routes': 0.2.11
+      '@privy-io/ethereum': 0.2.3-beta-20260826194301(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@privy-io/routes': 0.2.12
       canonicalize: 2.1.0
       eventemitter3: 5.0.4
       fetch-retry: 6.0.0
@@ -4948,7 +4940,7 @@ snapshots:
 
   '@privy-io/popup@0.0.5': {}
 
-  ? '@privy-io/react-auth@3.38.0-beta-20260821205628(@solana-program/memo@0.8.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@stripe/stripe-js@1.54.2)(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@3.25.76)'
+  ? '@privy-io/react-auth@3.39.0-beta-20260826194301(@solana-program/memo@0.8.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@stripe/stripe-js@1.54.2)(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@3.25.76)'
   : dependencies:
       '@base-org/account': 1.1.1(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@3.25.76)
       '@base-ui/react': 1.7.0(@types/react@19.2.18)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -4960,13 +4952,13 @@ snapshots:
       '@marsidev/react-turnstile': 1.6.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@privy-io/api-base': 1.9.5
       '@privy-io/api-types': 0.20.0
-      '@privy-io/are-addresses-equal': 0.0.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@privy-io/are-addresses-equal': 0.0.12-beta-20260826194301(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@privy-io/chains': 0.5.2
       '@privy-io/encoding': 0.2.2
-      '@privy-io/ethereum': 0.2.2(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
-      '@privy-io/js-sdk-core': 0.72.0-beta-20260821205628(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@privy-io/ethereum': 0.2.3-beta-20260826194301(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@privy-io/js-sdk-core': 0.72.1-beta-20260826194301(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@privy-io/popup': 0.0.5
-      '@privy-io/routes': 0.2.11
+      '@privy-io/routes': 0.2.12
       '@privy-io/urls': 0.0.5
       '@scure/base': 1.2.6
       '@simplewebauthn/browser': 13.3.0
@@ -5047,7 +5039,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@privy-io/routes@0.2.11':
+  '@privy-io/routes@0.2.12':
     dependencies:
       '@privy-io/api-types': 0.20.0
 
@@ -9916,23 +9908,6 @@ snapshots:
       isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       ox: 0.9.1(typescript@5.9.3)(zod@3.25.76)
       ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-
-  viem@2.55.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76):
-    dependencies:
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
-      isows: 1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      ox: 0.14.33(typescript@5.9.3)(zod@3.25.76)
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:

--- a/examples/privy-next-cards/src/components/sections/cards-api.ts
+++ b/examples/privy-next-cards/src/components/sections/cards-api.ts
@@ -9,13 +9,21 @@ export type Card = {
   id: string;
   /** Stripe Issuing card id — what Stripe's test helpers take. */
   provider_id: string;
+  /** `active`, `inactive` (frozen), or `canceled`. A replaced card is left `canceled`. */
+  status: string;
 };
 
+/** A card that is still usable. Cancelled cards stay in the list, so they have to be filtered out. */
+export const isOpen = (card: Card) => card.status !== "canceled";
+
 /**
- * The authenticated user's cards in one environment.
+ * The authenticated user's cards in one environment, newest first.
  *
  * Hand-rolled because the SDK exports no card-list hook, which is also why the demo needs it: it is
  * the only way to tell whether a user already has a card, and the only source of the Stripe card id.
+ *
+ * A user can accumulate several cards — replacing a card cancels the old one and issues a new one —
+ * so callers want the newest open card rather than simply the first.
  *
  * TODO: replace with an SDK card lookup once one exists.
  */
@@ -36,7 +44,16 @@ export const listCards = async ({
     },
   });
 
-  if (!response.ok) throw new Error("Could not list cards");
+  if (!response.ok) {
+    // Carry the status and the API's own message. The list request fails for reasons that are worth
+    // reading rather than collapsing into "no card": cards not enabled for this environment, no
+    // Stripe key saved for it, or a card the API could not enrich — it treats Stripe lookup and
+    // balance reads as all-or-none, so one bad card fails the whole page.
+    const detail = await response.text().catch(() => "");
+    throw new Error(
+      `Could not list ${environment} cards (${response.status})${detail ? `: ${detail.slice(0, 300)}` : ""}`,
+    );
+  }
 
   const { data }: { data: Card[] } = await response.json();
   return data;

--- a/examples/privy-next-cards/src/components/sections/cards.tsx
+++ b/examples/privy-next-cards/src/components/sections/cards.tsx
@@ -9,7 +9,7 @@ import { Modal } from "./modal";
 import { showSuccessToast, showErrorToast } from "../ui/custom-toast";
 import { findEmbeddedWallet } from "./find-embedded-wallet";
 import { simulateSpend } from "./simulate-spend";
-import { listCards } from "./cards-api";
+import { isOpen, listCards } from "./cards-api";
 
 // Loaded when the modal first opens rather than at first paint. Statically importing these puts
 // them and their transitive deps (~400kB) in the initial page bundle, which every visitor pays for
@@ -44,8 +44,21 @@ const CARD_CHAINS: Record<CardEnvironment, { id: string; label: string }> = {
   production: { id: "eip155:8453", label: "Base" },
 };
 
-/** Named in `CardSummaryView`'s footer legal disclosure as the Platform Provider. */
-const DEVELOPER_NAME = "Privy Cards Demo";
+/**
+ * Where a production card's USDC allowance goes: the mainnet USDC contract and the Bridge spender
+ * that pulls from it at spend time. `SignUpForCardView` requires this on `environment="production"`
+ * and builds it in for sandbox testnets, because Bridge does not publish its mainnet spender to the
+ * SDK. Both come from the Bridge production integration behind the app's card configuration.
+ *
+ * Read from env rather than hardcoded: the values are per-integration, and approving the wrong
+ * spender leaves a `ready` card that cannot spend. Production signup stays gated until both are set.
+ */
+const PRODUCTION_SPEND_APPROVAL = (() => {
+  const stablecoinAddress = process.env.NEXT_PUBLIC_CARD_USDC_ADDRESS;
+  const spenderAddress = process.env.NEXT_PUBLIC_CARD_SPENDER_ADDRESS;
+  if (!stablecoinAddress || !spenderAddress) return null;
+  return { stablecoinAddress, spenderAddress };
+})();
 
 /** Amount, in cents, of the simulated purchase used to put a row on the transaction list. */
 const TEST_SPEND_AMOUNT = 50;
@@ -64,6 +77,14 @@ const Cards = () => {
   const [openView, setOpenView] = useState<OpenView>(null);
   const [isSpending, setIsSpending] = useState(false);
   const [isLoadingCard, setIsLoadingCard] = useState(false);
+  // Why the card lookup failed, if it did. Kept apart from "no card yet": a failed lookup says
+  // nothing about whether a card exists, and reporting it as "no card" sends you off to sign up for
+  // one you already have.
+  const [cardLookupError, setCardLookupError] = useState<string | null>(null);
+  // How many cards the lookup found in total, open or not. Distinguishes "you have never had a card
+  // here" from "every card you have here is cancelled" — the same empty summary otherwise, and the
+  // second one is the confusing case, since the card does exist.
+  const [totalCards, setTotalCards] = useState(0);
 
   const wallet = findEmbeddedWallet(user?.linkedAccounts ?? []);
   const chain = CARD_CHAINS[environment];
@@ -80,16 +101,28 @@ const Cards = () => {
 
     let active = true;
     setIsLoadingCard(true);
+    setCardLookupError(null);
 
     void (async () => {
       try {
         const token = await getAccessToken();
         if (!token) throw new Error("No access token");
         const cards = await listCards({ environment, accessToken: token });
-        // One card per account, so the first is the card.
-        if (active) setCardId(cards[0]?.id ?? null);
-      } catch {
-        if (active) setCardId(null);
+        if (!active) return;
+        // Newest first, and cancelled cards stay in the list, so the newest open one is the live
+        // card. A replacement lands ahead of the card it closed.
+        setCardId(cards.find(isOpen)?.id ?? null);
+        setTotalCards(cards.length);
+      } catch (error) {
+        if (!active) return;
+        setCardId(null);
+        setTotalCards(0);
+        // Reported rather than swallowed. Silently treating a failed lookup as "no card yet" is how
+        // an existing card looks like a missing one.
+        setCardLookupError(
+          error instanceof Error ? error.message : "Card lookup failed",
+        );
+        console.error("Cards: card lookup failed", error);
       } finally {
         if (active) setIsLoadingCard(false);
       }
@@ -105,6 +138,14 @@ const Cards = () => {
     setCardId(readyCardId);
     showSuccessToast("Card is ready.");
     setOpenView("summary");
+  };
+
+  // A replacement closes the card the panel was opened on, so `CardSummaryView` does not adopt the
+  // new card — it shows a "card cancelled" banner and hands the new id here. Point the demo at the
+  // replacement and remount the panel on it; the `key` on the view is what forces the refetch.
+  const onReplaced = (newCardId: string) => {
+    setCardId(newCardId);
+    showSuccessToast("Card replaced. Showing the new card.");
   };
 
   // Stable so the modal's Escape listener and scroll lock are not torn down and re-applied on
@@ -154,17 +195,16 @@ const Cards = () => {
       description="Sign up for a card, then review its balance, transactions, and details."
       filepath="src/components/sections/cards"
       actions={[
-        // Hidden once a card exists. There is one card per account, so signing up again would only
-        // walk the disclosure steps and hand back the same card.
-        ...(cardId
-          ? []
-          : [
-              {
-                name: "Sign up for a card",
-                function: () => setOpenView("signup"),
-                disabled: !wallet,
-              },
-            ]),
+        // Always shown, card or no card. The flow is the point of the demo, so it stays reachable
+        // for a second look at the disclosure and KYC steps; a user who already has a card walks
+        // them again and the SDK hands back the card that exists rather than issuing another.
+        {
+          name: "Sign up for a card",
+          function: () => setOpenView("signup"),
+          // Production needs a spend-approval target; without one there is nothing to sign up into
+          // but a card that cannot spend.
+          disabled: !wallet || (!isSandbox && !PRODUCTION_SPEND_APPROVAL),
+        },
         {
           name: "View card summary",
           function: () => setOpenView("summary"),
@@ -213,12 +253,38 @@ const Cards = () => {
               className={`rounded-full px-2 py-0.5 text-[12px] ${
                 cardId
                   ? "bg-[#E8F5E9] text-[#1B5E20]"
-                  : "bg-[#E2E3F0] text-[#040217]"
+                  : cardLookupError
+                    ? "bg-[#FDECEA] text-[#7F1D1D]"
+                    : totalCards > 0
+                      ? "bg-[#FFF4E5] text-[#663C00]"
+                      : "bg-[#E2E3F0] text-[#040217]"
               }`}
             >
-              {isLoadingCard ? "Checking…" : cardId ? "Card created" : "No card yet"}
+              {isLoadingCard
+                ? "Checking…"
+                : cardId
+                  ? "Card created"
+                  : cardLookupError
+                    ? "Lookup failed"
+                    : totalCards > 0
+                      ? "Card cancelled"
+                      : "No card yet"}
             </span>
           </div>
+
+          {cardLookupError && (
+            <p className="mt-2 rounded-md bg-[#FDECEA] p-2 text-[13px] font-light break-words text-[#7F1D1D]">
+              {cardLookupError}
+            </p>
+          )}
+
+          {!cardLookupError && !cardId && totalCards > 0 && (
+            <p className="mt-2 text-[13px] font-light">
+              {totalCards === 1 ? "The card" : `All ${totalCards} cards`} on this
+              wallet {totalCards === 1 ? "has" : "have"} been cancelled, so there
+              is nothing to summarize. Sign up again for a new one.
+            </p>
+          )}
           <p className="font-light break-all">{wallet.address}</p>
 
           {isSandbox ? (
@@ -260,32 +326,57 @@ const Cards = () => {
 
       {!isSandbox && (
         <p className="mt-3 rounded-md bg-[#FFF4E5] p-3 text-[13px] font-light text-[#663C00]">
-          Production uses real money, and a card created here cannot spend yet:
-          the SDK publishes no mainnet Bridge spender, so signup skips the USDC
-          approval and still reports the card as ready. Simulated purchases are
-          sandbox-only &mdash; Stripe&apos;s test helpers do not exist for live
-          keys.
+          Production uses real money.{" "}
+          {PRODUCTION_SPEND_APPROVAL
+            ? "Signup grants a real USDC allowance to the Bridge spender configured in this deployment's env, so a card issued here can spend."
+            : "Signup is disabled until NEXT_PUBLIC_CARD_USDC_ADDRESS and NEXT_PUBLIC_CARD_SPENDER_ADDRESS are set — the SDK requires the mainnet spend-approval target, since Bridge does not publish it."}{" "}
+          Simulated purchases are sandbox-only &mdash; Stripe&apos;s test helpers
+          do not exist for live keys.
         </p>
       )}
 
       {openView === "signup" && wallet && (
         <Modal onClose={closeModal} label="Sign up for a card">
-          <SignUpForCardView
-            environment={environment}
-            walletId={wallet.id}
-            chainId={chain.id}
-            onCardReady={onCardReady}
-            onClose={closeModal}
-          />
+          {/* `SignUpForCardViewProps` is discriminated on `environment` — production requires a
+              `spendApproval` target, sandbox rejects one — so the environment cannot be threaded
+              through a single element. The shared props are spread into both. */}
+          {isSandbox ? (
+            <SignUpForCardView
+              environment="sandbox"
+              walletId={wallet.id}
+              chainId={chain.id}
+              onCardReady={onCardReady}
+              onClose={closeModal}
+            />
+          ) : PRODUCTION_SPEND_APPROVAL ? (
+            <SignUpForCardView
+              environment="production"
+              spendApproval={PRODUCTION_SPEND_APPROVAL}
+              walletId={wallet.id}
+              chainId={chain.id}
+              onCardReady={onCardReady}
+              onClose={closeModal}
+            />
+          ) : (
+            <p className="p-4 text-[14px] font-light">
+              Set <code>NEXT_PUBLIC_CARD_USDC_ADDRESS</code> and{" "}
+              <code>NEXT_PUBLIC_CARD_SPENDER_ADDRESS</code> to sign up on
+              production. Without the spend-approval target the card could not
+              spend, so signup is disabled rather than approving a guess.
+            </p>
+          )}
         </Modal>
       )}
 
       {openView === "summary" && cardId && (
         <Modal onClose={closeModal} label="Card summary">
+          {/* Keyed on the card id so a replacement remounts the view on the new card rather than
+              leaving the closed one's data in place. */}
           <CardSummaryView
+            key={cardId}
             cardId={cardId}
-            developerName={DEVELOPER_NAME}
             environment={environment}
+            onReplaced={onReplaced}
             onClose={closeModal}
           />
         </Modal>


### PR DESCRIPTION
## Summary

Updates `examples/privy-next-cards` for the current `SignUpForCardView` and `CardSummaryView` APIs, and pins the prerelease that carries them.

Both components are still in prerelease, so the pin is exact rather than a range.

### `CardSummaryView`

- The `developerName` prop has been removed. The footer disclosure now names the Platform Provider from the app's legal name in the app config, so that value is set in the Privy dashboard instead of passed in. Documented as a setup step in the README.
- Adds the `onReplaced` callback. Replacing a card closes the current one and issues a new one, and the view stays scoped to the card that closed, so the example points its card id at the replacement and keys the view on it to remount.
- Because a replacement leaves the previous card cancelled in the card list, the lookup now selects the newest card that is not cancelled rather than the first card returned.

### `SignUpForCardView`

- Props are discriminated on `environment`. Sandbox resolves the spend-approval target from the SDK's built-in testnet values; production requires an explicit `spendApproval` naming the stablecoin contract and spender to approve. The example renders the two variants separately and reads the production target from `NEXT_PUBLIC_CARD_USDC_ADDRESS` and `NEXT_PUBLIC_CARD_SPENDER_ADDRESS`, keeping production signup disabled until both are set.
- Production signup now completes the on-chain spend approval, so the previous note about production cards being unable to spend has been replaced with the configuration this requires.

### Example improvements

- The signup action stays available once a card exists. After cancelling a card it is the only way to get a working one again.
- The card lookup now distinguishes its outcomes instead of always reporting "No card yet": a failed request reports the response status and message, and a set of entirely cancelled cards reports "Card cancelled" with a prompt to sign up again.

## Testing

`tsc --noEmit`, `eslint`, and `next build` pass against the pinned prerelease. The flow was run locally in both sandbox and production. The replacement hand-off and a full production signup have not yet been driven end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
