### PR TITLE
feat(privy-next-cards): fund cards from Tempo instead of Base

### DIFF
--- a/examples/privy-next-cards/.env.example
+++ b/examples/privy-next-cards/.env.example
@@ -1,10 +1,10 @@
 NEXT_PUBLIC_PRIVY_APP_ID=your-privy-app-id
 
 # Optional. Only needed to sign up for a card in PRODUCTION. `SignUpForCardView` requires the
-# on-chain spend-approval target on production — the mainnet USDC contract and the Bridge spender
-# that pulls from it — because the SDK only ships built-in targets for sandbox testnets. Get both
-# from the Bridge production integration behind your app's card configuration. Leave them blank to
-# run sandbox only; production signup stays disabled until both are set.
+# on-chain spend-approval target on production — the Tempo mainnet USDC contract and the Bridge
+# spender that pulls from it — because the SDK only ships a built-in target for Tempo Testnet
+# (Moderato). Get both from the Bridge production integration behind your app's card configuration.
+# Leave them blank to run sandbox only; production signup stays disabled until both are set.
 NEXT_PUBLIC_CARD_USDC_ADDRESS=
 NEXT_PUBLIC_CARD_SPENDER_ADDRESS=
 

--- a/examples/privy-next-cards/README.md
+++ b/examples/privy-next-cards/README.md
@@ -4,7 +4,9 @@ This Next.js example shows how to issue and manage cards for your users with the
 
 It is scaffolded from [`privy-next-starter`](../../privy-next-starter), trimmed down to just the card flow — the wallet, funding, linking, signer, and MFA sections are intentionally removed (opted out under `sectionOverrides` in [`.sync-manifest.json`](../../.sync-manifest.json), so base syncs don't re-add them).
 
-> **⚠️ Production signup needs a spend-approval target.** `SignUpForCardView` grants the card's USDC spend allowance to a Bridge spender. The SDK ships built-in targets for sandbox testnets, but not for mainnets — on `environment="production"` it requires a `spendApproval` prop naming the USDC contract and Bridge spender to approve. This demo reads both from env vars and keeps production signup disabled until they are set. See [Environments](#environments).
+The card funds from **Tempo** — Tempo Testnet (Moderato) in sandbox, Tempo mainnet in production.
+
+> **⚠️ Production signup needs a spend-approval target.** `SignUpForCardView` grants the card's stablecoin spend allowance to a Bridge spender. The SDK ships built-in targets for sandbox testnets, but not for mainnets — on `environment="production"` it requires a `spendApproval` prop naming the USDC contract and Bridge spender to approve. This demo reads both from env vars and keeps production signup disabled until they are set. See [Environments](#environments).
 
 ## Flow
 
@@ -27,8 +29,10 @@ Because a replacement leaves the old card behind as `canceled`, a user accumulat
 ## Source map
 
 - [`src/app/page.tsx`](./src/app/page.tsx): Login state, page layout, and the `Cards` section
-- [`src/providers/providers.tsx`](./src/providers/providers.tsx): Privy provider configuration; EVM-only, creates an embedded Ethereum wallet on login
-- [`src/components/sections/cards.tsx`](./src/components/sections/cards.tsx): Hosts both card views, owns the environment toggle and card id, and holds the chain map and the production spend-approval target
+- [`src/chains.ts`](./src/chains.ts): The two Tempo chains, the sandbox fee token, and the per-environment chain map
+- [`src/providers/providers.tsx`](./src/providers/providers.tsx): Privy provider configuration; EVM-only, declares both Tempo chains, creates an embedded Ethereum wallet on login
+- [`src/components/sections/cards.tsx`](./src/components/sections/cards.tsx): Hosts both card views, owns the environment toggle and card id, and holds the production spend-approval target
+- [`src/components/sections/tempo-faucet.ts`](./src/components/sections/tempo-faucet.ts) and [`src/app/api/faucet/route.ts`](./src/app/api/faucet/route.ts): Testnet faucet top-up via the `tempo_fundAddress` RPC method
 - [`src/components/sections/cards-api.ts`](./src/components/sections/cards-api.ts): Lists the user's cards for an environment and picks the newest open one, since the SDK exports no card-list hook
 - [`src/components/sections/find-embedded-wallet.ts`](./src/components/sections/find-embedded-wallet.ts): Picks the embedded EVM wallet whose Privy wallet id the card views need
 - [`src/components/sections/modal.tsx`](./src/components/sections/modal.tsx): Centered 440px modal the card views render inside
@@ -80,7 +84,7 @@ In the [Privy dashboard](https://dashboard.privy.io), configure the app used by 
 
 ### 5. Fund the wallet
 
-The card spends USDC on Base Sepolia from the user's embedded wallet, and the approval transaction needs gas. The demo shows the wallet address and links to both faucets once you log in. Without Base Sepolia ETH the flow dead-ends on the approval step with generic error copy.
+The card spends pathUSD on Tempo Testnet (Moderato) from the user's embedded wallet. Log in and press **Fund wallet from faucet** — Moderato's faucet is the `tempo_fundAddress` JSON-RPC method on the chain's own endpoint, so there is no separate faucet service or API key. See [Funding on Tempo](#funding-on-tempo).
 
 ### 6. Start the development server
 
@@ -98,10 +102,12 @@ Production needs its own credentials, separate from sandbox: a Bridge production
 
 |  | Sandbox | Production |
 | --- | --- | --- |
-| Funding chain | Base Sepolia (`eip155:84532`) | Base (`eip155:8453`), real USDC |
+| Funding chain | Tempo Testnet (Moderato) (`eip155:42431`) | Tempo (`eip155:4217`), real USDC |
+| Funding token | pathUSD, from the faucet | set by `NEXT_PUBLIC_CARD_USDC_ADDRESS`, real money |
 | Spend approval target | built in | `spendApproval` prop, from env |
 | Card signup | ✅ | ✅ once the target is set |
 | Card summary | ✅ | ✅ |
+| Faucet top-up | ✅ | ❌ testnet only |
 | Simulated purchase | ✅ | ❌ not possible |
 
 **Production needs the spend-approval target.** `SignUpForCardView`'s props are discriminated on `environment`: sandbox resolves the USDC contract and Bridge spender from the SDK's built-in testnet targets and rejects a supplied one, while production **requires** a `spendApproval` — Bridge does not publish its mainnet targets to the SDK, and approving the wrong spender would leave a `ready` card that cannot spend. Passing neither, or passing one on sandbox, is a type error rather than a silently unusable card.
@@ -109,15 +115,27 @@ Production needs its own credentials, separate from sandbox: a Bridge production
 This demo reads the production target from two public env vars and gates signup on them:
 
 ```env
-NEXT_PUBLIC_CARD_USDC_ADDRESS=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913
+NEXT_PUBLIC_CARD_USDC_ADDRESS=0x…
 NEXT_PUBLIC_CARD_SPENDER_ADDRESS=0x…
 ```
 
-The USDC address is Base mainnet's; the spender is the issuer address from the Bridge **production** integration behind your app's card configuration. With either missing, the production **Sign up for a card** button is disabled and the modal says which vars to set. Sandbox is unaffected and needs no configuration.
+The USDC address is Tempo mainnet's; the spender is the issuer address from the Bridge **production** integration behind your app's card configuration. With either missing, the production **Sign up for a card** button is disabled and the modal says which vars to set. Sandbox is unaffected and needs no configuration.
 
 `SignUpForCardView` also accepts a Solana target (`{stablecoinAddress, programId, merchantId}`) for a `solana:*` `chainId`; this demo is EVM-only, so it always supplies the EVM shape.
 
 **Why simulated purchases are sandbox-only.** Stripe's Issuing test helpers do not exist for live keys — there is no API to fabricate a live authorization, so live spend must be a real purchase at a real merchant. The button is hidden in production, and the route refuses non-test keys.
+
+## Funding on Tempo
+
+Tempo's fee model differs from an ETH-gas chain in a way that shows up throughout this demo:
+
+- **No native gas token.** Fees are paid in a TIP-20 stablecoin, with automatic conversion between supported tokens. There is no separate "get some ETH for gas" step — one stablecoin balance covers everything. [`src/chains.ts`](./src/chains.ts) pins the sandbox chain's `feeToken` to pathUSD, the same token the card spends, so a single faucet top-up serves both.
+- **The approval is sponsored.** `SignUpForCardView` sends the spend-approval transaction with `sponsor: true` and only falls back to a pre-funded send if sponsorship is unavailable. On the sponsored path the wallet needs no fee balance at all to complete signup — the balance matters for spending.
+- **The faucet is an RPC method.** Moderato exposes `tempo_fundAddress` on its own endpoint (`https://rpc.moderato.tempo.xyz`), which hands out 1M each of pathUSD, AlphaUSD, BetaUSD, and ThetaUSD. **Fund wallet from faucet** calls it through [a route handler](./src/app/api/faucet/route.ts), since the RPC endpoint sends no CORS headers for browsers. There is also a [browser faucet](https://tempo.xyz/developers/docs/quickstart/faucet) if you would rather fund an address by hand.
+
+The sandbox spend-approval target the SDK builds in for `eip155:42431` uses pathUSD (`0x20C0…0000`) as its `stablecoinAddress`, which is why that is the token the demo names and the fee token it pins.
+
+Both Tempo chains are declared in [`providers.tsx`](./src/providers/providers.tsx) under `supportedChains`. This is not cosmetic: the approval step calls `wallet_switchEthereumChain` to the card's chain before reading the allowance, and an undeclared chain fails that switch with an error that says nothing about chain configuration.
 
 ## Simulating a purchase
 
@@ -133,7 +151,7 @@ Notes:
 
 - This is a **server-only** variable, read by [`src/app/api/test-spend/route.ts`](./src/app/api/test-spend/route.ts). Never expose a Stripe secret key to the browser via `NEXT_PUBLIC_`. The route refuses to run with anything that isn't an `sk_test_`/`rk_test_` key and caps the amount at $100.
 - The button is a demo affordance, not something to deploy. Anyone who can reach the route can create authorizations on the configured account's cards.
-- **It does not move the balance.** `CardSummaryView` shows the funding wallet's on-chain balance, so a simulated purchase changes the transaction list only. Real settlement pulls USDC through the Bridge spender.
+- **It does not move the balance.** `CardSummaryView` shows the funding wallet's on-chain balance, so a simulated purchase changes the transaction list only. Real settlement pulls the stablecoin through the Bridge spender.
 - Reopen the modal to see the new row — closing it unmounts the view, so opening again refetches.
 - Stripe may **decline** the authorization, since stablecoin-backed cards check funding. A declined authorization still appears in the list, and the toast reports the reason.
 

--- a/examples/privy-next-cards/package.json
+++ b/examples/privy-next-cards/package.json
@@ -10,11 +10,12 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
-    "@privy-io/react-auth": "3.39.0-beta-20260826194301",
+    "@privy-io/react-auth": "3.39.0-beta-20260827192706",
     "next": "15.5.7",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-toastify": "^11.0.5"
+    "react-toastify": "^11.0.5",
+    "viem": "^2.55.19"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/examples/privy-next-cards/pnpm-lock.yaml
+++ b/examples/privy-next-cards/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0(react@19.1.0)
       '@privy-io/react-auth':
-        specifier: 3.39.0-beta-20260826194301
-        version: 3.39.0-beta-20260826194301(@solana-program/memo@0.8.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@stripe/stripe-js@1.54.2)(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@3.25.76)
+        specifier: 3.39.0-beta-20260827192706
+        version: 3.39.0-beta-20260827192706(@solana-program/memo@0.8.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@stripe/stripe-js@1.54.2)(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@3.25.76)
       next:
         specifier: 15.5.7
         version: 15.5.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -26,6 +26,9 @@ importers:
       react-toastify:
         specifier: ^11.0.5
         version: 11.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      viem:
+        specifier: ^2.55.19
+        version: 2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3
@@ -670,14 +673,14 @@ packages:
   '@phosphor-icons/webcomponents@2.1.5':
     resolution: {integrity: sha512-JcvQkZxvcX2jK+QCclm8+e8HXqtdFW9xV4/kk2aL9Y3dJA2oQVt+pzbv1orkumz3rfx4K9mn9fDoMr1He1yr7Q==}
 
-  '@privy-io/api-base@1.9.5':
-    resolution: {integrity: sha512-q3bfy/BFF8kktodfsVzpR2UprSN1RZkGwenrMtJwFxgwSKEUdG3BKjNUulH66F+FSa7TajxmKzZeXgVhxA9sXg==}
+  '@privy-io/api-base@1.10.0-beta-20260827192706':
+    resolution: {integrity: sha512-BvKpb39XENYmuVDY8tyQpRfiwAOWagPgH7I5fAG8/Exl+SwHQFR+p7jwU5SgEdtNHEaCnw+vflKlu+6Ubf9xVA==}
 
   '@privy-io/api-types@0.20.0':
     resolution: {integrity: sha512-CqzPGb4xj2jJC07UiBhbdBf7a02UhI047IVu2rr6EP5xImhR0iD2aSxCbjVo9fx07TNM6Sv/O14Dcrqc96c8uw==}
 
-  '@privy-io/are-addresses-equal@0.0.12-beta-20260826194301':
-    resolution: {integrity: sha512-2i9NBus2tFGKP2bQsuA2R4VdrosmfAm2TtSF2ksHn/zVzF8Uq2ihM0b3g7zuWpCBiIzJEakdoM1emDSOnXq60A==}
+  '@privy-io/are-addresses-equal@0.0.12-beta-20260827192706':
+    resolution: {integrity: sha512-dTnxDAbqLpLF3SGpeTEdjvL+JZ/zVnkS68iPQXT1Kz4qjurzshr6SOaMFfq6PIB/5BJjcuEJrWezH6pIYJzCBg==}
 
   '@privy-io/chains@0.5.2':
     resolution: {integrity: sha512-h6Zr9hOFNdZamiv/XuFPPJwaMeoWJBOPCqSczr12Nh731tYHhCdCXr5RG+1WvCowbvj3xCXWokkAlByxnU2xsw==}
@@ -685,13 +688,13 @@ packages:
   '@privy-io/encoding@0.2.2':
     resolution: {integrity: sha512-bQHM5AB+F3/MIEaJ0WcFbCqAyuls7nUbQ34AlyctibPK1tmYL0tc9D2voeHo9q2S31nlgIKLEDJ65VZc+pcv6Q==}
 
-  '@privy-io/ethereum@0.2.3-beta-20260826194301':
-    resolution: {integrity: sha512-jU/fdjTXukedLU/5y7xmLPNog2Tz6IsJpw5hQ96aQ3kTFhW/Mv7EnXbV9yU4tiTgngSYHBrPKmg+K+6/bZRCdA==}
+  '@privy-io/ethereum@0.2.3-beta-20260827192706':
+    resolution: {integrity: sha512-DUWMh95l4djzuPwRJYCwFPmjlhvV73uAtpHqLW/8rPLIckrYgVZIkqGazLu4UvMkKwwsluCMetw7lMF1uIbpdg==}
     peerDependencies:
       viem: 2.55.15
 
-  '@privy-io/js-sdk-core@0.72.1-beta-20260826194301':
-    resolution: {integrity: sha512-Xr3xTPJwh7yNUBHlQ4bYlVeAUnTFU1Zi45M881WPvFzKtw1Ko7FCvsIxY+ZHG3unR2Gu6gGaWmwIItDMR+iciw==}
+  '@privy-io/js-sdk-core@0.72.1-beta-20260827192706':
+    resolution: {integrity: sha512-iYV1EBgGz4Q0v4X1ARAMjzcjWQxdnMqgC3JGMzicANaKx38pOGzPNKmNzmWg+OjML7NTCbw/u1WUuc5Uy3lHlw==}
     peerDependencies:
       permissionless: ^0.2.47
       viem: 2.55.15
@@ -704,8 +707,8 @@ packages:
   '@privy-io/popup@0.0.5':
     resolution: {integrity: sha512-lIwErJA86rHmLkSyapv86Z6hVzoLl544iZsVgk4tcVCHxbLBlLI4UmgLDmviNTZdp+uY0VEZe8fjUQIPpa6tZg==}
 
-  '@privy-io/react-auth@3.39.0-beta-20260826194301':
-    resolution: {integrity: sha512-PH/B77BX4OagKFt88XbFKtPkDZ64WQJzfJVSOq0fCPGJXqdk147oHyw7Fr77bIKPXJmOlI93O3S3fZBpj9X27g==}
+  '@privy-io/react-auth@3.39.0-beta-20260827192706':
+    resolution: {integrity: sha512-sqWaO46SuiOgykgVjzygjegisS1BUQySwNfIX63DPXA0JGs2V8+XB45XswPkBoUFcGLD2+mWacki6V2EGLjVcg==}
     peerDependencies:
       '@abstract-foundation/agw-client': ^1.0.0
       '@farcaster/mini-app-solana': ^1.0.0
@@ -4424,11 +4427,11 @@ snapshots:
 
   '@floating-ui/utils@0.2.12': {}
 
-  '@gemini-wallet/core@0.3.2(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@gemini-wallet/core@0.3.2(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
       '@metamask/rpc-errors': 7.0.2
       eventemitter3: 5.0.1
-      viem: 2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
@@ -4895,13 +4898,13 @@ snapshots:
     dependencies:
       lit: 3.3.0
 
-  '@privy-io/api-base@1.9.5':
+  '@privy-io/api-base@1.10.0-beta-20260827192706':
     dependencies:
       zod: 3.25.76
 
   '@privy-io/api-types@0.20.0': {}
 
-  '@privy-io/are-addresses-equal@0.0.12-beta-20260826194301(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@privy-io/are-addresses-equal@0.0.12-beta-20260827192706(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       viem: 2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
@@ -4916,17 +4919,17 @@ snapshots:
     dependencies:
       '@scure/base': 1.2.6
 
-  '@privy-io/ethereum@0.2.3-beta-20260826194301(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@privy-io/ethereum@0.2.3-beta-20260827192706(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
       viem: 2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
 
-  '@privy-io/js-sdk-core@0.72.1-beta-20260826194301(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@privy-io/js-sdk-core@0.72.1-beta-20260827192706(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
-      '@privy-io/api-base': 1.9.5
+      '@privy-io/api-base': 1.10.0-beta-20260827192706
       '@privy-io/api-types': 0.20.0
       '@privy-io/chains': 0.5.2
       '@privy-io/encoding': 0.2.2
-      '@privy-io/ethereum': 0.2.3-beta-20260826194301(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@privy-io/ethereum': 0.2.3-beta-20260827192706(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@privy-io/routes': 0.2.12
       canonicalize: 2.1.0
       eventemitter3: 5.0.4
@@ -4940,7 +4943,7 @@ snapshots:
 
   '@privy-io/popup@0.0.5': {}
 
-  ? '@privy-io/react-auth@3.39.0-beta-20260826194301(@solana-program/memo@0.8.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@stripe/stripe-js@1.54.2)(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@3.25.76)'
+  ? '@privy-io/react-auth@3.39.0-beta-20260827192706(@solana-program/memo@0.8.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@stripe/stripe-js@1.54.2)(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@3.25.76)'
   : dependencies:
       '@base-org/account': 1.1.1(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@3.25.76)
       '@base-ui/react': 1.7.0(@types/react@19.2.18)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -4950,13 +4953,13 @@ snapshots:
       '@headlessui/react': 2.2.10(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@heroicons/react': 2.2.0(react@19.1.0)
       '@marsidev/react-turnstile': 1.6.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@privy-io/api-base': 1.9.5
+      '@privy-io/api-base': 1.10.0-beta-20260827192706
       '@privy-io/api-types': 0.20.0
-      '@privy-io/are-addresses-equal': 0.0.12-beta-20260826194301(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@privy-io/are-addresses-equal': 0.0.12-beta-20260827192706(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@privy-io/chains': 0.5.2
       '@privy-io/encoding': 0.2.2
-      '@privy-io/ethereum': 0.2.3-beta-20260826194301(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
-      '@privy-io/js-sdk-core': 0.72.1-beta-20260826194301(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@privy-io/ethereum': 0.2.3-beta-20260827192706(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@privy-io/js-sdk-core': 0.72.1-beta-20260827192706(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@privy-io/popup': 0.0.5
       '@privy-io/routes': 0.2.12
       '@privy-io/urls': 0.0.5
@@ -6401,19 +6404,19 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
-  '@wagmi/connectors@6.2.0(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(@wagmi/core@2.22.1(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)':
+  '@wagmi/connectors@6.2.0(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(@wagmi/core@2.22.1(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)':
     dependencies:
       '@base-org/account': 2.4.0(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@3.25.76)
       '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@gemini-wallet/core': 0.3.2(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@gemini-wallet/core': 0.3.2(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@metamask/sdk': 0.33.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@walletconnect/ethereum-provider': 2.21.1(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      porto: 0.2.35(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(@wagmi/core@2.22.1(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
-      viem: 2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      porto: 0.2.35(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(@wagmi/core@2.22.1(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
+      viem: 2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -6459,11 +6462,11 @@ snapshots:
       - wagmi
       - zod
 
-  '@wagmi/core@2.22.1(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@wagmi/core@2.22.1(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zustand: 5.0.0(@types/react@19.2.18)(react@19.1.0)(use-sync-external-store@1.4.0(react@19.1.0))
     optionalDependencies:
       '@tanstack/query-core': 5.101.4
@@ -9183,21 +9186,21 @@ snapshots:
 
   pony-cause@2.1.11: {}
 
-  porto@0.2.35(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(@wagmi/core@2.22.1(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)):
+  porto@0.2.35(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(@wagmi/core@2.22.1(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)):
     dependencies:
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       hono: 4.13.3
       idb-keyval: 6.3.0
       mipd: 0.0.7(typescript@5.9.3)
       ox: 0.9.17(typescript@5.9.3)(zod@4.4.3)
-      viem: 2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zod: 4.4.3
       zustand: 5.0.15(@types/react@19.2.18)(react@19.1.0)(use-sync-external-store@1.4.0(react@19.1.0))
     optionalDependencies:
       '@tanstack/react-query': 5.101.4(react@19.1.0)
       react: 19.1.0
       typescript: 5.9.3
-      wagmi: 2.19.5(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+      wagmi: 2.19.5(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -9966,14 +9969,14 @@ snapshots:
       - utf-8-validate
       - zod
 
-  wagmi@2.19.5(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76):
+  wagmi@2.19.5(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76):
     dependencies:
       '@tanstack/react-query': 5.101.4(react@19.1.0)
-      '@wagmi/connectors': 6.2.0(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(@wagmi/core@2.22.1(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@wagmi/connectors': 6.2.0(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(@wagmi/core@2.22.1(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       react: 19.1.0
       use-sync-external-store: 1.4.0(react@19.1.0)
-      viem: 2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -10120,7 +10123,7 @@ snapshots:
       '@wallet-standard/base': 1.1.1
       '@wallet-standard/features': 1.1.1
       viem: 2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      wagmi: 2.19.5(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+      wagmi: 2.19.5(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.55.19(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@azure/app-configuration'

--- a/examples/privy-next-cards/src/app/api/faucet/route.ts
+++ b/examples/privy-next-cards/src/app/api/faucet/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+
+import { TEMPO_TESTNET } from "@/chains";
+
+/**
+ * Moderato's faucet is a JSON-RPC method on the chain's own endpoint rather than a separate service,
+ * so funding a test wallet is one call with no API key. Mainnet has no equivalent — this is testnet
+ * only, which is why the route hardcodes the testnet RPC instead of taking a chain from the caller.
+ */
+const TEMPO_TESTNET_RPC = TEMPO_TESTNET.rpcUrls.default.http[0];
+
+/** Proxied through a route handler because the RPC endpoint does not send CORS headers for browsers. */
+export async function POST(request: Request) {
+  let address: unknown;
+  try {
+    ({ address } = await request.json());
+  } catch {
+    return NextResponse.json({ error: "Expected a JSON body" }, { status: 400 });
+  }
+
+  // The faucet takes the address as-is, so a malformed one comes back as an opaque RPC error. Check
+  // the shape here to say something useful instead.
+  if (typeof address !== "string" || !/^0x[0-9a-fA-F]{40}$/.test(address)) {
+    return NextResponse.json(
+      { error: "Expected `address` to be a 0x-prefixed 20-byte address" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const response = await fetch(TEMPO_TESTNET_RPC, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tempo_fundAddress",
+        // Lowercased: the faucet is documented as taking a lowercase address.
+        params: [address.toLowerCase()],
+      }),
+    });
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: `Faucet RPC returned ${response.status}` },
+        { status: 502 },
+      );
+    }
+
+    // A JSON-RPC error arrives with HTTP 200 and an `error` member, so the status check above is not
+    // enough on its own.
+    const body = await response.json();
+    if (body.error) {
+      return NextResponse.json(
+        { error: body.error.message ?? "Faucet RPC call failed" },
+        { status: 502 },
+      );
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error ? error.message : "Could not reach the faucet",
+      },
+      { status: 502 },
+    );
+  }
+}

--- a/examples/privy-next-cards/src/chains.ts
+++ b/examples/privy-next-cards/src/chains.ts
@@ -1,0 +1,52 @@
+import { tempo, tempoModerato } from "viem/chains";
+
+/**
+ * pathUSD, the TIP-20 test stablecoin the faucet hands out on Moderato. This is also the
+ * `stablecoinAddress` in the SDK's built-in sandbox spend-approval target for `eip155:42431`, so the
+ * card's allowance and the wallet's balance are denominated in the same token.
+ */
+export const PATH_USD = "0x20C0000000000000000000000000000000000000" as const;
+
+/**
+ * Tempo has no native gas token — fees are paid in a TIP-20 stablecoin. Pinning `feeToken` to the
+ * same token the card spends means one faucet top-up covers both the approval transaction and the
+ * card, instead of the two-token dance an ETH-gas chain needs.
+ *
+ * Privy sponsors the card's approval transaction (`sponsor: true`), so in practice the fee token only
+ * matters on the pre-funded fallback path when sponsorship is unavailable.
+ */
+export const TEMPO_TESTNET = tempoModerato.extend({ feeToken: PATH_USD });
+
+/**
+ * Tempo mainnet. No `feeToken` here: the production stablecoin comes from the Bridge integration via
+ * `NEXT_PUBLIC_CARD_USDC_ADDRESS`, so hardcoding a fee token would be a guess about a real balance.
+ */
+export const TEMPO_MAINNET = tempo;
+
+export type CardEnvironment = "sandbox" | "production";
+
+/**
+ * The chain each environment funds cards from, and how to label it.
+ *
+ * Sandbox is Tempo Testnet (Moderato), the one Tempo chain the SDK ships a built-in spend-approval
+ * target for. Production is Tempo mainnet, so its stablecoin is real money and its approval target
+ * has to be supplied — see `PRODUCTION_SPEND_APPROVAL` in `cards.tsx`.
+ */
+export const CARD_CHAINS: Record<
+  CardEnvironment,
+  { id: string; label: string; token: string | null }
+> = {
+  sandbox: {
+    id: `eip155:${TEMPO_TESTNET.id}`,
+    label: TEMPO_TESTNET.name,
+    token: "pathUSD",
+  },
+  // No token name for production: which stablecoin a live card settles in comes from the Bridge
+  // integration via `NEXT_PUBLIC_CARD_USDC_ADDRESS`, so naming one here would be a guess about
+  // someone else's configuration. Tempo mainnet's only initialized TIP-20 today is pathUSD.
+  production: {
+    id: `eip155:${TEMPO_MAINNET.id}`,
+    label: TEMPO_MAINNET.name,
+    token: null,
+  },
+};

--- a/examples/privy-next-cards/src/components/sections/cards.tsx
+++ b/examples/privy-next-cards/src/components/sections/cards.tsx
@@ -10,7 +10,9 @@ import { showSuccessToast, showErrorToast } from "../ui/custom-toast";
 import { Badge, type BadgeVariant } from "../ui/badge";
 import { findEmbeddedWallet } from "./find-embedded-wallet";
 import { simulateSpend } from "./simulate-spend";
+import { fundWallet } from "./tempo-faucet";
 import { isOpen, listCards } from "./cards-api";
+import { CARD_CHAINS, type CardEnvironment } from "@/chains";
 
 // Loaded when the modal first opens rather than at first paint. Statically importing these puts
 // them and their transitive deps (~400kB) in the initial page bundle, which every visitor pays for
@@ -32,24 +34,12 @@ const CardSummaryView = dynamic(
   { ssr: false },
 );
 
-type CardEnvironment = "sandbox" | "production";
-
 /**
- * The chain each environment funds cards from, and how to label it.
- *
- * Production is Base mainnet, so its USDC is real money. Any sandbox testnet with a published
- * Bridge spender works in sandbox; Base Sepolia is the default here.
- */
-const CARD_CHAINS: Record<CardEnvironment, { id: string; label: string }> = {
-  sandbox: { id: "eip155:84532", label: "Base Sepolia" },
-  production: { id: "eip155:8453", label: "Base" },
-};
-
-/**
- * Where a production card's USDC allowance goes: the mainnet USDC contract and the Bridge spender
- * that pulls from it at spend time. `SignUpForCardView` requires this on `environment="production"`
- * and builds it in for sandbox testnets, because Bridge does not publish its mainnet spender to the
- * SDK. Both come from the Bridge production integration behind the app's card configuration.
+ * Where a production card's stablecoin allowance goes: the mainnet USDC contract and the Bridge
+ * spender that pulls from it at spend time. `SignUpForCardView` requires this on
+ * `environment="production"` and builds it in for sandbox testnets, because Bridge does not publish
+ * its mainnet spender to the SDK. Both come from the Bridge production integration behind the app's
+ * card configuration.
  *
  * Read from env rather than hardcoded: the values are per-integration, and approving the wrong
  * spender leaves a `ready` card that cannot spend. Production signup stays gated until both are set.
@@ -77,6 +67,7 @@ const Cards = () => {
   const [cardId, setCardId] = useState<string | null>(null);
   const [openView, setOpenView] = useState<OpenView>(null);
   const [isSpending, setIsSpending] = useState(false);
+  const [isFunding, setIsFunding] = useState(false);
   const [isLoadingCard, setIsLoadingCard] = useState(false);
   // Why the card lookup failed, if it did. Kept apart from "no card yet": a failed lookup says
   // nothing about whether a card exists, and reporting it as "no card" sends you off to sign up for
@@ -172,6 +163,24 @@ const Cards = () => {
     setEnvironment(next);
   };
 
+  const onFundWallet = async () => {
+    if (!wallet) return;
+
+    setIsFunding(true);
+    try {
+      await fundWallet(wallet.address);
+      showSuccessToast(
+        `Faucet sent test stablecoins to the wallet. ${chain.token} balances may take a moment to show up.`,
+      );
+    } catch (error) {
+      showErrorToast(
+        error instanceof Error ? error.message : "Faucet request failed",
+      );
+    } finally {
+      setIsFunding(false);
+    }
+  };
+
   const onSimulateSpend = async () => {
     if (!cardId) return;
 
@@ -224,10 +233,16 @@ const Cards = () => {
           function: () => setOpenView("summary"),
           disabled: !wallet || !cardId,
         },
-        // Stripe's Issuing test helpers only exist in test mode, so there is no way to fabricate a
-        // production authorization. Live spend has to be a real purchase.
+        // Both sandbox-only. Moderato's faucet is an RPC method on the chain itself, and Stripe's
+        // Issuing test helpers only exist in test mode — there is no way to fabricate a production
+        // authorization, so live spend has to be a real purchase.
         ...(isSandbox
           ? [
+              {
+                name: isFunding ? "Funding…" : "Fund wallet from faucet",
+                function: onFundWallet,
+                disabled: !wallet || isFunding,
+              },
               {
                 name: isSpending
                   ? "Simulating…"
@@ -286,31 +301,17 @@ const Cards = () => {
 
           {isSandbox ? (
             <p className="mt-2 font-light">
-              The card spends USDC on {chain.label} from this wallet.{" "}
-              {cardId ? "Keep it topped up with" : "Before signing up, give it"}{" "}
-              <a
-                className="text-primary underline"
-                href="https://docs.base.org/base-chain/tools/network-faucets"
-                target="_blank"
-                rel="noreferrer"
-              >
-                Base Sepolia ETH
-              </a>{" "}
-              for gas and{" "}
-              <a
-                className="text-primary underline"
-                href="https://faucet.circle.com/"
-                target="_blank"
-                rel="noreferrer"
-              >
-                testnet USDC
-              </a>{" "}
-              to spend.
+              The card spends {chain.token} on {chain.label} from this wallet.
+              Tempo has no native gas token — fees are paid in the same
+              stablecoin — so one faucet top-up covers both the approval and the
+              card.
             </p>
           ) : (
             <p className="mt-2 font-light">
-              The card spends real USDC on {chain.label} from this wallet, and
-              the approval transaction needs real ETH for gas.
+              The card spends the real stablecoin configured for this deployment
+              on {chain.label} from this wallet. Fees are paid in stablecoin
+              rather than a native gas token, so no separate gas balance is
+              needed.
             </p>
           )}
         </div>

--- a/examples/privy-next-cards/src/components/sections/tempo-faucet.ts
+++ b/examples/privy-next-cards/src/components/sections/tempo-faucet.ts
@@ -1,0 +1,16 @@
+/**
+ * Tops the wallet up with Moderato test stablecoins by way of the faucet route handler, which calls
+ * the `tempo_fundAddress` RPC method. Testnet only.
+ */
+export const fundWallet = async (address: string): Promise<void> => {
+  const response = await fetch("/api/faucet", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ address }),
+  });
+
+  if (!response.ok) {
+    const body = await response.json().catch(() => null);
+    throw new Error(body?.error ?? `Faucet request failed (${response.status})`);
+  }
+};

--- a/examples/privy-next-cards/src/providers/providers.tsx
+++ b/examples/privy-next-cards/src/providers/providers.tsx
@@ -2,6 +2,8 @@
 
 import { PrivyProvider } from "@privy-io/react-auth";
 
+import { TEMPO_MAINNET, TEMPO_TESTNET } from "@/chains";
+
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
     <PrivyProvider
@@ -14,6 +16,12 @@ export default function Providers({ children }: { children: React.ReactNode }) {
             createOnLogin: "users-without-wallets",
           },
         },
+        // Both Tempo chains have to be declared here, not just labelled in the Cards section. The
+        // spend-approval step calls `wallet_switchEthereumChain` to the card's chain before it reads
+        // the allowance, and a chain the provider does not know about fails that switch — which
+        // surfaces as a generic approval error rather than anything pointing at chain config.
+        defaultChain: TEMPO_TESTNET,
+        supportedChains: [TEMPO_TESTNET, TEMPO_MAINNET],
         appearance: { walletChainType: "ethereum-only" },
       }}
     >


### PR DESCRIPTION
Points the cards demo at **Tempo** instead of Base — Tempo Testnet (Moderato, `eip155:42431`) in sandbox, Tempo mainnet (`eip155:4217`) in production.

## Why it's more than a chain-id swap

**No native gas token.** Tempo fees are paid in a TIP-20 stablecoin, so the "get some Sepolia ETH for gas" step and both external faucet links are gone. `src/chains.ts` pins the sandbox `feeToken` to pathUSD — the same token the card spends — so one top-up covers the approval transaction and the card.

**The sandbox token is pathUSD, not USDC.** It's the `stablecoinAddress` in the SDK's built-in spend-approval target for `eip155:42431`.

**Both chains are declared under `supportedChains`.** Required, not cosmetic: the approval step calls `wallet_switchEthereumChain` to the card's chain before reading the allowance, and an undeclared chain fails that switch with an error that points nowhere near chain config.

**The faucet is an RPC method.** Moderato exposes `tempo_fundAddress` on its own endpoint, so a **Fund wallet from faucet** action replaces the external links. It goes through a route handler because the RPC sends no CORS headers. Each call sends 1,000,000 of each test stablecoin and is repeatable.

## Production

Production names no token — which stablecoin a live card settles in comes from the Bridge integration via `NEXT_PUBLIC_CARD_USDC_ADDRESS`, so hardcoding one would be a guess about someone else's setup. The README's example env block is a placeholder rather than Base's USDC address, which has no code on Tempo.

## Changes

- `src/chains.ts` *(new)* — the two Tempo chains, the sandbox fee token, and the per-environment chain map, shared by the provider and the Cards section
- `src/components/sections/tempo-faucet.ts` + `src/app/api/faucet/route.ts` *(new)* — the faucet call. Named `tempo-faucet` to avoid colliding with the base starter's unrelated `fund-wallet.tsx`, which this example already excludes in `.sync-manifest.json`
- `@privy-io/react-auth` bumped to the beta carrying the built-in Moderato approval target; no card-prop changes, so sandbox needs no `spendApproval`

Sandbox card signup tested end-to-end against Moderato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
