### PR TITLE
Update card issuing example for imperative signup

### DIFF
--- a/examples/privy-next-cards/README.md
+++ b/examples/privy-next-cards/README.md
@@ -1,6 +1,6 @@
 # Cards with Privy
 
-This Next.js example shows how to issue and manage cards for your users with the Privy React SDK, using the `SignUpForCardView` and `CardSummaryView` components from `@privy-io/react-auth/ui`.
+This Next.js example shows how to issue and manage cards for your users with the Privy React SDK, using `useSignUpForCard`, `SignUpForCardView`, and `CardSummaryView` from `@privy-io/react-auth/ui`.
 
 It is scaffolded from [`privy-next-starter`](../../privy-next-starter), trimmed down to just the card flow — the wallet, funding, linking, signer, and MFA sections are intentionally removed (opted out under `sectionOverrides` in [`.sync-manifest.json`](../../.sync-manifest.json), so base syncs don't re-add them).
 
@@ -11,8 +11,8 @@ The card funds from **Tempo** — Tempo Testnet (Moderato) in sandbox, Tempo mai
 ## Flow
 
 1. Sign in with Privy. The provider creates an embedded Ethereum wallet for users without one.
-2. Press **Sign up for a card**. `SignUpForCardView` walks the e-sign disclosure, the bank agreements (which name your app, the issuing bank, and Bridge as the card-program manager), the provider terms, and KYC, then creates the card and prompts for the on-chain USDC spend approval.
-3. On success it fires `onCardReady` with the card id, and the demo hands straight off to the summary.
+2. Press **Sign up for a card**. The demo calls `useSignUpForCard().signUp(...)`, and `SignUpForCardView` walks the e-sign disclosure, the bank agreements (which name your app, the issuing bank, and Bridge as the card-program manager), the provider terms, and KYC, then creates the card and prompts for the on-chain USDC spend approval.
+3. On success the `signUp` promise returns the card id, and the demo hands straight off to the summary.
 4. `CardSummaryView` shows the balance, card face, transactions, card details and reveal, statement downloads, and the freeze/cancel/replace actions.
 5. Optionally press **Simulate a $0.50 purchase** to put a real row on the transaction list. See [Simulating a purchase](#simulating-a-purchase).
 
@@ -31,7 +31,7 @@ Because a replacement leaves the old card behind as `canceled`, a user accumulat
 - [`src/app/page.tsx`](./src/app/page.tsx): Login state, page layout, and the `Cards` section
 - [`src/chains.ts`](./src/chains.ts): The two Tempo chains, the sandbox fee token, and the per-environment chain map
 - [`src/providers/providers.tsx`](./src/providers/providers.tsx): Privy provider configuration; EVM-only, declares both Tempo chains, creates an embedded Ethereum wallet on login
-- [`src/components/sections/cards.tsx`](./src/components/sections/cards.tsx): Hosts both card views, owns the environment toggle and card id, and holds the production spend-approval target
+- [`src/components/sections/cards.tsx`](./src/components/sections/cards.tsx): Launches signup with `useSignUpForCard`, hosts both card views, owns the environment toggle and card id, and holds the production spend-approval target
 - [`src/components/sections/tempo-faucet.ts`](./src/components/sections/tempo-faucet.ts) and [`src/app/api/faucet/route.ts`](./src/app/api/faucet/route.ts): Testnet faucet top-up via the `tempo_fundAddress` RPC method
 - [`src/components/sections/cards-api.ts`](./src/components/sections/cards-api.ts): Lists the user's cards for an environment and picks the newest open one, since the SDK exports no card-list hook
 - [`src/components/sections/find-embedded-wallet.ts`](./src/components/sections/find-embedded-wallet.ts): Picks the embedded EVM wallet whose Privy wallet id the card views need
@@ -157,15 +157,15 @@ Notes:
 
 ## SDK version
 
-`CardSummaryView` and `SignUpForCardView` are not in a stable `@privy-io/react-auth` release yet, so this example pins the beta that contains both. Their props are still moving, so the pin is exact rather than a caret range — a newer beta can be a breaking change.
+`CardSummaryView`, `SignUpForCardView`, and `useSignUpForCard` are not in a stable `@privy-io/react-auth` release yet, so this example pins the beta that contains all three. Their APIs are still moving, so the pin is exact rather than a caret range — a newer beta can be a breaking change.
 
 To check what you actually have installed:
 
 ```bash
-rg 'SignUpForCardView|CardSummaryView|spendApproval|onReplaced|developerName' node_modules/@privy-io/react-auth/dist/dts/ui.d.ts
+rg 'SignUpForCardView|useSignUpForCard|SignUpForCardOptions|CardSummaryView|spendApproval|onReplaced|developerName' node_modules/@privy-io/react-auth/dist/dts/ui.d.ts
 ```
 
-Both component names must appear, `spendApproval` and `onReplaced` must appear, and `developerName` must not — that combination is the beta this example is written against. An older beta fails `tsc` on all three. If you swap in a locally built tarball to test unreleased SDK changes, note that a local build and a published release can share a version string with different contents, so a later `pnpm install` can silently replace it with no resolution error — run the check above again after any install. Don't commit a `file:` dependency; it is machine-local.
+Both component names and the signup hook/types must appear, `SignUpForCardView` must take no props, `spendApproval` and `onReplaced` must appear, and `developerName` must not — that combination is the beta this example is written against. An older beta fails `tsc` on the imperative signup API. If you swap in a locally built tarball to test unreleased SDK changes, note that a local build and a published release can share a version string with different contents, so a later `pnpm install` can silently replace it with no resolution error — run the check above again after any install. Don't commit a `file:` dependency; it is machine-local.
 
 ## Relevant links
 

--- a/examples/privy-next-cards/package.json
+++ b/examples/privy-next-cards/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
-    "@privy-io/react-auth": "3.39.0-beta-20260827192706",
+    "@privy-io/react-auth": "3.39.0-beta-20260828180615",
     "next": "15.5.7",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/examples/privy-next-cards/pnpm-lock.yaml
+++ b/examples/privy-next-cards/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0(react@19.1.0)
       '@privy-io/react-auth':
-        specifier: 3.39.0-beta-20260827192706
-        version: 3.39.0-beta-20260827192706(@solana-program/memo@0.8.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@stripe/stripe-js@1.54.2)(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@3.25.76)
+        specifier: 3.39.0-beta-20260828180615
+        version: 3.39.0-beta-20260828180615(@solana-program/memo@0.8.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@stripe/stripe-js@1.54.2)(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@3.25.76)
       next:
         specifier: 15.5.7
         version: 15.5.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -673,14 +673,14 @@ packages:
   '@phosphor-icons/webcomponents@2.1.5':
     resolution: {integrity: sha512-JcvQkZxvcX2jK+QCclm8+e8HXqtdFW9xV4/kk2aL9Y3dJA2oQVt+pzbv1orkumz3rfx4K9mn9fDoMr1He1yr7Q==}
 
-  '@privy-io/api-base@1.10.0-beta-20260827192706':
-    resolution: {integrity: sha512-BvKpb39XENYmuVDY8tyQpRfiwAOWagPgH7I5fAG8/Exl+SwHQFR+p7jwU5SgEdtNHEaCnw+vflKlu+6Ubf9xVA==}
+  '@privy-io/api-base@1.10.0-beta-20260828180615':
+    resolution: {integrity: sha512-oTxEhdqI5nLrtJJs0MTg6t24WQ+AjDRziJzLTRbPyWbfrVQKbPstT7ntVHY9lm7+W7xiYFoO5bXeXFKp4ilLmw==}
 
   '@privy-io/api-types@0.20.0':
     resolution: {integrity: sha512-CqzPGb4xj2jJC07UiBhbdBf7a02UhI047IVu2rr6EP5xImhR0iD2aSxCbjVo9fx07TNM6Sv/O14Dcrqc96c8uw==}
 
-  '@privy-io/are-addresses-equal@0.0.12-beta-20260827192706':
-    resolution: {integrity: sha512-dTnxDAbqLpLF3SGpeTEdjvL+JZ/zVnkS68iPQXT1Kz4qjurzshr6SOaMFfq6PIB/5BJjcuEJrWezH6pIYJzCBg==}
+  '@privy-io/are-addresses-equal@0.0.12-beta-20260828180615':
+    resolution: {integrity: sha512-ncPThaxW9UNm1huEh2/jdsLYU9wj7B4JpZrWJ8yrTZNgsxPejsLjSqVm6FoVRszEGcLIdAyG26Sf8Jhsp4QV2w==}
 
   '@privy-io/chains@0.5.2':
     resolution: {integrity: sha512-h6Zr9hOFNdZamiv/XuFPPJwaMeoWJBOPCqSczr12Nh731tYHhCdCXr5RG+1WvCowbvj3xCXWokkAlByxnU2xsw==}
@@ -688,16 +688,16 @@ packages:
   '@privy-io/encoding@0.2.2':
     resolution: {integrity: sha512-bQHM5AB+F3/MIEaJ0WcFbCqAyuls7nUbQ34AlyctibPK1tmYL0tc9D2voeHo9q2S31nlgIKLEDJ65VZc+pcv6Q==}
 
-  '@privy-io/ethereum@0.2.3-beta-20260827192706':
-    resolution: {integrity: sha512-DUWMh95l4djzuPwRJYCwFPmjlhvV73uAtpHqLW/8rPLIckrYgVZIkqGazLu4UvMkKwwsluCMetw7lMF1uIbpdg==}
+  '@privy-io/ethereum@0.2.3-beta-20260828180615':
+    resolution: {integrity: sha512-n9PNA+dVm1pUldS50pFZja4JOAbU/XX/SGTA0Jj7j7KNPrpPsWpPRrsyIyEJOcR+qLKRD9w3seGMxXFSTiOidA==}
     peerDependencies:
-      viem: 2.55.15
+      viem: 2.56.0
 
-  '@privy-io/js-sdk-core@0.72.1-beta-20260827192706':
-    resolution: {integrity: sha512-iYV1EBgGz4Q0v4X1ARAMjzcjWQxdnMqgC3JGMzicANaKx38pOGzPNKmNzmWg+OjML7NTCbw/u1WUuc5Uy3lHlw==}
+  '@privy-io/js-sdk-core@0.72.1-beta-20260828180615':
+    resolution: {integrity: sha512-29oQAx1Q06St9kO1aLFGbJQC7HI9djUh1sxW576H9FXcmWTa5qc0D8yFzRYduzwxPjMIictDyxeCgBWRUAmMmQ==}
     peerDependencies:
       permissionless: ^0.2.47
-      viem: 2.55.15
+      viem: 2.56.0
     peerDependenciesMeta:
       permissionless:
         optional: true
@@ -707,8 +707,8 @@ packages:
   '@privy-io/popup@0.0.5':
     resolution: {integrity: sha512-lIwErJA86rHmLkSyapv86Z6hVzoLl544iZsVgk4tcVCHxbLBlLI4UmgLDmviNTZdp+uY0VEZe8fjUQIPpa6tZg==}
 
-  '@privy-io/react-auth@3.39.0-beta-20260827192706':
-    resolution: {integrity: sha512-sqWaO46SuiOgykgVjzygjegisS1BUQySwNfIX63DPXA0JGs2V8+XB45XswPkBoUFcGLD2+mWacki6V2EGLjVcg==}
+  '@privy-io/react-auth@3.39.0-beta-20260828180615':
+    resolution: {integrity: sha512-GIw5JYBEpVuruL2rJs0h1CKsfTZHQitRE2/qYjgV58HRxlfKrnFgYl0SfKEKplQa9+IR1uQaXBheXKY9lKiIuw==}
     peerDependencies:
       '@abstract-foundation/agw-client': ^1.0.0
       '@farcaster/mini-app-solana': ^1.0.0
@@ -3942,8 +3942,8 @@ packages:
       typescript:
         optional: true
 
-  viem@2.55.15:
-    resolution: {integrity: sha512-ka9SfSJ3ZfhuUEzTGmufwALRvEPVKM068tF0AwfdRZagqA3yuFa/QoXIvALzr9y47m4Wiisl3yEoYWuFQso6Ng==}
+  viem@2.56.0:
+    resolution: {integrity: sha512-JmkgIk4jN+im4oguLxwPv19pwSaGH9kcGSq25Ilm55106ULBBMNR3eWKKA0wZoeyLPSHIiOwZ4sGceEYEIq7LA==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -4898,15 +4898,15 @@ snapshots:
     dependencies:
       lit: 3.3.0
 
-  '@privy-io/api-base@1.10.0-beta-20260827192706':
+  '@privy-io/api-base@1.10.0-beta-20260828180615':
     dependencies:
       zod: 3.25.76
 
   '@privy-io/api-types@0.20.0': {}
 
-  '@privy-io/are-addresses-equal@0.0.12-beta-20260827192706(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@privy-io/are-addresses-equal@0.0.12-beta-20260828180615(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      viem: 2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.56.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -4919,17 +4919,17 @@ snapshots:
     dependencies:
       '@scure/base': 1.2.6
 
-  '@privy-io/ethereum@0.2.3-beta-20260827192706(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@privy-io/ethereum@0.2.3-beta-20260828180615(viem@2.56.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
-      viem: 2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.56.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
 
-  '@privy-io/js-sdk-core@0.72.1-beta-20260827192706(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@privy-io/js-sdk-core@0.72.1-beta-20260828180615(viem@2.56.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
-      '@privy-io/api-base': 1.10.0-beta-20260827192706
+      '@privy-io/api-base': 1.10.0-beta-20260828180615
       '@privy-io/api-types': 0.20.0
       '@privy-io/chains': 0.5.2
       '@privy-io/encoding': 0.2.2
-      '@privy-io/ethereum': 0.2.3-beta-20260827192706(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@privy-io/ethereum': 0.2.3-beta-20260828180615(viem@2.56.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@privy-io/routes': 0.2.12
       canonicalize: 2.1.0
       eventemitter3: 5.0.4
@@ -4939,11 +4939,11 @@ snapshots:
       libphonenumber-js: 1.13.11
       set-cookie-parser: 2.7.2
     optionalDependencies:
-      viem: 2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.56.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
 
   '@privy-io/popup@0.0.5': {}
 
-  ? '@privy-io/react-auth@3.39.0-beta-20260827192706(@solana-program/memo@0.8.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@stripe/stripe-js@1.54.2)(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@3.25.76)'
+  ? '@privy-io/react-auth@3.39.0-beta-20260828180615(@solana-program/memo@0.8.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@stripe/stripe-js@1.54.2)(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@3.25.76)'
   : dependencies:
       '@base-org/account': 1.1.1(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@3.25.76)
       '@base-ui/react': 1.7.0(@types/react@19.2.18)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -4953,13 +4953,13 @@ snapshots:
       '@headlessui/react': 2.2.10(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@heroicons/react': 2.2.0(react@19.1.0)
       '@marsidev/react-turnstile': 1.6.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@privy-io/api-base': 1.10.0-beta-20260827192706
+      '@privy-io/api-base': 1.10.0-beta-20260828180615
       '@privy-io/api-types': 0.20.0
-      '@privy-io/are-addresses-equal': 0.0.12-beta-20260827192706(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@privy-io/are-addresses-equal': 0.0.12-beta-20260828180615(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@privy-io/chains': 0.5.2
       '@privy-io/encoding': 0.2.2
-      '@privy-io/ethereum': 0.2.3-beta-20260827192706(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
-      '@privy-io/js-sdk-core': 0.72.1-beta-20260827192706(viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@privy-io/ethereum': 0.2.3-beta-20260828180615(viem@2.56.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@privy-io/js-sdk-core': 0.72.1-beta-20260828180615(viem@2.56.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@privy-io/popup': 0.0.5
       '@privy-io/routes': 0.2.12
       '@privy-io/urls': 0.0.5
@@ -4986,7 +4986,7 @@ snapshots:
       styled-components: 6.5.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       stylis: 4.4.0
       tinycolor2: 1.6.0
-      viem: 2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.56.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       x402: 0.7.3(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.1.0))(@types/react@19.2.18)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       zustand: 5.0.15(@types/react@19.2.18)(react@19.1.0)(use-sync-external-store@1.4.0(react@19.1.0))
     optionalDependencies:
@@ -9918,7 +9918,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.55.15(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76):
+  viem@2.56.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
@@ -9926,7 +9926,7 @@ snapshots:
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
       isows: 1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      ox: 0.14.33(typescript@5.9.3)(zod@3.25.76)
+      ox: 0.14.34(typescript@5.9.3)(zod@3.25.76)
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.9.3

--- a/examples/privy-next-cards/src/components/sections/cards.tsx
+++ b/examples/privy-next-cards/src/components/sections/cards.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { usePrivy } from "@privy-io/react-auth";
+import { useSignUpForCard } from "@privy-io/react-auth/ui";
 import dynamic from "next/dynamic";
 
 import Section from "../reusables/section";
@@ -62,6 +63,7 @@ type OpenView = "signup" | "summary" | null;
 
 const Cards = () => {
   const { user, getAccessToken } = usePrivy();
+  const { signUp } = useSignUpForCard();
   const userId = user?.id;
   const [environment, setEnvironment] = useState<CardEnvironment>("sandbox");
   const [cardId, setCardId] = useState<string | null>(null);
@@ -139,12 +141,6 @@ const Cards = () => {
     };
   }, [userId, environment, getAccessToken]);
 
-  const onCardReady = (readyCardId: string) => {
-    setCardId(readyCardId);
-    showSuccessToast("Card is ready.");
-    setOpenView("summary");
-  };
-
   // A replacement closes the card the panel was opened on, so `CardSummaryView` does not adopt the
   // new card — it shows a "card cancelled" banner and hands the new id here. Point the demo at the
   // replacement and remount the panel on it; the `key` on the view is what forces the refetch.
@@ -161,6 +157,44 @@ const Cards = () => {
     // Close first: the open view is bound to the environment it was opened for.
     setOpenView(null);
     setEnvironment(next);
+  };
+
+  const openCardSignUp = async () => {
+    if (!wallet || (!isSandbox && !PRODUCTION_SPEND_APPROVAL)) return;
+
+    setOpenView("signup");
+    try {
+      let result;
+      if (isSandbox) {
+        result = await signUp({
+          environment: "sandbox",
+          walletId: wallet.id,
+          chainId: chain.id,
+        });
+      } else {
+        if (!PRODUCTION_SPEND_APPROVAL) return;
+        result = await signUp({
+          environment: "production",
+          spendApproval: PRODUCTION_SPEND_APPROVAL,
+          walletId: wallet.id,
+          chainId: chain.id,
+        });
+      }
+      setCardId(result.id);
+      showSuccessToast("Card is ready.");
+      setOpenView("summary");
+    } catch (error) {
+      if (
+        !(error instanceof Error) ||
+        error.message !== "User cancelled card sign-up"
+      ) {
+        showErrorToast(
+          error instanceof Error ? error.message : "Card sign-up failed",
+        );
+      }
+    } finally {
+      setOpenView((view) => (view === "signup" ? null : view));
+    }
   };
 
   const onFundWallet = async () => {
@@ -223,7 +257,7 @@ const Cards = () => {
         // them again and the SDK hands back the card that exists rather than issuing another.
         {
           name: "Sign up for a card",
-          function: () => setOpenView("signup"),
+          function: openCardSignUp,
           // Production needs a spend-approval target; without one there is nothing to sign up into
           // but a card that cannot spend.
           disabled: !wallet || (!isSandbox && !PRODUCTION_SPEND_APPROVAL),
@@ -333,36 +367,15 @@ const Cards = () => {
         </p>
       )}
 
-      {openView === "signup" && wallet && (
-        <Modal onClose={closeModal} label="Sign up for a card">
-          {/* `SignUpForCardViewProps` is discriminated on `environment` — production requires a
-              `spendApproval` target, sandbox rejects one — so the environment cannot be threaded
-              through a single element. The shared props are spread into both. */}
-          {isSandbox ? (
-            <SignUpForCardView
-              environment="sandbox"
-              walletId={wallet.id}
-              chainId={chain.id}
-              onCardReady={onCardReady}
-              onClose={closeModal}
-            />
-          ) : PRODUCTION_SPEND_APPROVAL ? (
-            <SignUpForCardView
-              environment="production"
-              spendApproval={PRODUCTION_SPEND_APPROVAL}
-              walletId={wallet.id}
-              chainId={chain.id}
-              onCardReady={onCardReady}
-              onClose={closeModal}
-            />
-          ) : (
-            <p className="p-4 text-[14px] font-light">
-              Set <code>NEXT_PUBLIC_CARD_USDC_ADDRESS</code> and{" "}
-              <code>NEXT_PUBLIC_CARD_SPENDER_ADDRESS</code> to sign up on
-              production. Without the spend-approval target the card could not
-              spend, so signup is disabled rather than approving a guess.
-            </p>
-          )}
+      {openView === "signup" && (
+        <Modal
+          onClose={closeModal}
+          label="Sign up for a card"
+          dismissible={false}
+        >
+          {/* The hook owns the active flow and settles its promise from this view's controls.
+              Backdrop and Escape dismissal stay disabled so the view always gets to settle it. */}
+          <SignUpForCardView />
         </Modal>
       )}
 

--- a/examples/privy-next-cards/src/components/sections/modal.tsx
+++ b/examples/privy-next-cards/src/components/sections/modal.tsx
@@ -6,7 +6,8 @@ import { useEffect } from "react";
  * Centered modal that hosts the card views.
  *
  * The width matches what the card components are designed against, so they render at their
- * intended size rather than stretching. Closes on backdrop click and on Escape.
+ * intended size rather than stretching. Dismissible views close on backdrop click and Escape;
+ * controlled flows can keep both disabled until their own controls settle them.
  *
  * Mount it conditionally — being mounted *is* being open. The card views fetch on mount, so
  * rendering one inside a hidden modal would fire requests for a dialog nobody opened.
@@ -15,14 +16,16 @@ export const Modal = ({
   onClose,
   label,
   children,
+  dismissible = true,
 }: {
   onClose: () => void;
   label: string;
   children: React.ReactNode;
+  dismissible?: boolean;
 }) => {
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
+      if (dismissible && event.key === "Escape") onClose();
     };
 
     document.addEventListener("keydown", onKeyDown);
@@ -34,13 +37,13 @@ export const Modal = ({
       document.removeEventListener("keydown", onKeyDown);
       document.body.style.overflow = "";
     };
-  }, [onClose]);
+  }, [dismissible, onClose]);
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       <div
         className="absolute inset-0 bg-black/50"
-        onClick={onClose}
+        onClick={dismissible ? onClose : undefined}
         aria-hidden="true"
       />
       <div


### PR DESCRIPTION
## Summary

- pin the card example to the latest React Auth beta
- launch card signup through `useSignUpForCard` and consume its returned card ID
- keep the signup host modal mounted until the SDK flow settles
- update the example documentation for the imperative signup API